### PR TITLE
[DSL] Variable assignments, syntactic sugar, and comments

### DIFF
--- a/dsl/progs/now/drop_a_class.sched
+++ b/dsl/progs/now/drop_a_class.sched
@@ -1,6 +1,6 @@
 classes A, B;
 
-policy = fifo[A];
+policy = A;
 
 return policy
 

--- a/dsl/progs/now/drop_a_class.sched
+++ b/dsl/progs/now/drop_a_class.sched
@@ -1,6 +1,6 @@
-classes A, B
+classes A, B;
 
-policy = fifo[A]
+policy = fifo[A];
 
 return policy
 

--- a/dsl/progs/now/fifo_1_class.sched
+++ b/dsl/progs/now/fifo_1_class.sched
@@ -1,5 +1,5 @@
-classes A
+classes A;
 
-policy = fifo[A]
+policy = fifo[A];
 
 return policy

--- a/dsl/progs/now/fifo_1_class.sched
+++ b/dsl/progs/now/fifo_1_class.sched
@@ -1,5 +1,5 @@
 classes A;
 
-policy = fifo[A];
+policy = A;
 
 return policy

--- a/dsl/progs/now/fifo_1_class_sugar.sched
+++ b/dsl/progs/now/fifo_1_class_sugar.sched
@@ -1,5 +1,6 @@
-classes A
+classes A;
 
-policy = A
+policy = (A);
+// sample test comment 1 !@#$%^&*( 0_+-=) []{}||:"<>?, ./;'`~
 
 return policy

--- a/dsl/progs/now/fifo_1_class_sugar.sched
+++ b/dsl/progs/now/fifo_1_class_sugar.sched
@@ -1,6 +1,7 @@
 classes A;
 
 policy = (A);
-// sample test comment 1 !@#$%^&*( 0_+-=) []{}||:"<>?, ./;'`~
+// Sample test comment
+// ~~~~!@#$%^&*()_` =  +{\[]}; :'"<>,. /?
 
 return policy

--- a/dsl/progs/now/fifo_1_class_sugar.sched
+++ b/dsl/progs/now/fifo_1_class_sugar.sched
@@ -1,7 +1,6 @@
 classes A;
 
-policy = (A);
+policy = A;
 // Sample test comment
-// ~~~~!@#$%^&*()_` =  +{\[]}; :'"<>,. /?
 
 return policy

--- a/dsl/progs/now/fifo_n_classes.sched
+++ b/dsl/progs/now/fifo_n_classes.sched
@@ -1,5 +1,5 @@
-classes A, B, C
+classes A, B, C;
 
-policy = fifo[A, B, C]
+policy = fifo[A, B, C];
 
 return policy

--- a/dsl/progs/now/rr_1_class.sched
+++ b/dsl/progs/now/rr_1_class.sched
@@ -1,5 +1,5 @@
-classes A
+classes A;
 
-policy = rr[fifo[A]]
+policy = rr[fifo[A]];
 
 return policy

--- a/dsl/progs/now/rr_1_class.sched
+++ b/dsl/progs/now/rr_1_class.sched
@@ -1,5 +1,5 @@
 classes A;
 
-policy = rr[fifo[A]];
+policy = rr[A];
 
 return policy

--- a/dsl/progs/now/rr_2_classes.sched
+++ b/dsl/progs/now/rr_2_classes.sched
@@ -1,5 +1,5 @@
-classes A, B
+classes A, B;
 
-policy = rr[fifo[A], fifo[B]]
+policy = rr[fifo[A], fifo[B]];
 
 return policy

--- a/dsl/progs/now/rr_2_classes.sched
+++ b/dsl/progs/now/rr_2_classes.sched
@@ -1,5 +1,5 @@
 classes A, B;
 
-policy = rr[fifo[A], fifo[B]];
+policy = rr[A, B];
 
 return policy

--- a/dsl/progs/now/rr_hier.sched
+++ b/dsl/progs/now/rr_hier.sched
@@ -1,11 +1,11 @@
-classes B, RP, RT
+classes B, RP, RT;
 // B represents packets that came from Buffalo
 // R? represents packets that came from Rochester
 // RP packets are destined for Pittsburgh
 // RT packets are destined for Toronto
 
-r_policy = rr[fifo[RP], fifo[RT]]
-policy = rr[fifo[B], r_policy]
+r_policy = rr[fifo[RP], fifo[RT]];
+policy = rr[fifo[B], r_policy];
 
 return policy
 

--- a/dsl/progs/now/rr_hier.sched
+++ b/dsl/progs/now/rr_hier.sched
@@ -4,8 +4,8 @@ classes B, RP, RT;
 // RP packets are destined for Pittsburgh
 // RT packets are destined for Toronto
 
-r_policy = rr[fifo[RP], fifo[RT]];
-policy = rr[fifo[B], r_policy];
+r_policy = rr[RP, RT];
+policy = rr[B, r_policy];
 
 return policy
 

--- a/dsl/progs/now/rr_hier_merge_sugar.sched
+++ b/dsl/progs/now/rr_hier_merge_sugar.sched
@@ -1,4 +1,4 @@
-classes BX, BY, RP, RT
+classes BX, BY, RP, RT;
 // B* represents packets that came from Buffalo
 // BX packets are destined for Xanadu
 // BY packets are destined for Yangon
@@ -6,9 +6,9 @@ classes BX, BY, RP, RT
 // RP packets are destined for Pittsburgh
 // RT packets are destined for Toronto
 
-b_policy = fifo[BX, BY]
-r_policy = rr[RP, RT]
-policy = rr[b_policy, r_policy]
+b_policy = fifo[BX, BY];
+r_policy = rr[RP, RT];
+policy = rr[b_policy, r_policy];
 
 return policy
 

--- a/dsl/progs/now/rr_hier_merge_sugar.sched
+++ b/dsl/progs/now/rr_hier_merge_sugar.sched
@@ -6,8 +6,8 @@ classes BX, BY, RP, RT;
 // RP packets are destined for Pittsburgh
 // RT packets are destined for Toronto
 
-b_policy = fifo[(BX), (BY)];
-r_policy = rr[(RP), (RT)];
+b_policy = fifo[BX, BY];
+r_policy = rr[RP, RT];
 policy = rr[b_policy, r_policy];
 
 return policy

--- a/dsl/progs/now/rr_hier_merge_sugar.sched
+++ b/dsl/progs/now/rr_hier_merge_sugar.sched
@@ -6,8 +6,8 @@ classes BX, BY, RP, RT;
 // RP packets are destined for Pittsburgh
 // RT packets are destined for Toronto
 
-b_policy = fifo[BX, BY];
-r_policy = rr[RP, RT];
+b_policy = fifo[(BX), (BY)];
+r_policy = rr[(RP), (RT)];
 policy = rr[b_policy, r_policy];
 
 return policy

--- a/dsl/progs/now/rr_hier_sugar.sched
+++ b/dsl/progs/now/rr_hier_sugar.sched
@@ -1,11 +1,11 @@
-classes B, RP, RT
+classes B, RP, RT;
 // B represents packets that came from Buffalo
 // R? represents packets that came from Rochester
 // RP packets are destined for Pittsburgh
 // RT packets are destined for Toronto
 
-r_policy = rr[RP, RT]
-policy = rr[B, r_policy]
+r_policy = rr[RP, RT];
+policy = rr[B, r_policy];
 
 return policy
 

--- a/dsl/progs/soon/rr_n_class_hier.sched
+++ b/dsl/progs/soon/rr_n_class_hier.sched
@@ -1,7 +1,7 @@
 classes A, B, CU, CV, CW, CX;
 
-c_policy = rr[rr[CU, CV], rr[CW, CX]];
-policy = rr[A, B, c_policy];
+c_policy = rr[rr[(CU), (CV)], rr[(CW), (CX)]];
+policy = rr[(A), (B), c_policy];
 
 return policy
 

--- a/dsl/progs/soon/rr_n_class_hier.sched
+++ b/dsl/progs/soon/rr_n_class_hier.sched
@@ -1,7 +1,7 @@
 classes A, B, CU, CV, CW, CX;
 
-c_policy = rr[rr[(CU), (CV)], rr[(CW), (CX)]];
-policy = rr[(A), (B), c_policy];
+c_policy = rr[rr[CU, CV], rr[CW, CX]];
+policy = rr[A, B, c_policy];
 
 return policy
 

--- a/dsl/progs/soon/rr_n_class_hier.sched
+++ b/dsl/progs/soon/rr_n_class_hier.sched
@@ -1,7 +1,7 @@
-classes A, B, CU, CV, CW, CX
+classes A, B, CU, CV, CW, CX;
 
-c_policy = rr[rr[CU, CV], rr[CW, CX]]
-policy = rr[A, B, c_policy]
+c_policy = rr[rr[CU, CV], rr[CW, CX]];
+policy = rr[A, B, c_policy];
 
 return policy
 

--- a/dsl/progs/soon/rr_n_classes.sched
+++ b/dsl/progs/soon/rr_n_classes.sched
@@ -1,5 +1,5 @@
-classes A, B, C
+classes A, B, C;
 
-policy = rr[A, B, C]
+policy = rr[A, B, C];
 
 return policy

--- a/dsl/progs/soon/rr_n_classes.sched
+++ b/dsl/progs/soon/rr_n_classes.sched
@@ -1,5 +1,5 @@
 classes A, B, C;
 
-policy = rr[A, B, C];
+policy = rr[(A), (B), (C)];
 
 return policy

--- a/dsl/progs/soon/rr_n_classes.sched
+++ b/dsl/progs/soon/rr_n_classes.sched
@@ -1,5 +1,5 @@
 classes A, B, C;
 
-policy = rr[(A), (B), (C)];
+policy = rr[A, B, C];
 
 return policy

--- a/dsl/progs/soon/rr_strict_n_classes_hier.sched
+++ b/dsl/progs/soon/rr_strict_n_classes_hier.sched
@@ -1,7 +1,7 @@
 classes A, B, CU, CV, CW, CX;
 
-c_policy = rr[rr[(CU), (CV)], strict[(CW), (CX)]];
-policy = strict[(A), (B), c_policy];
+c_policy = rr[rr[CU, CV], strict[CW, CX]];
+policy = strict[A, B, c_policy];
 
 return policy
 

--- a/dsl/progs/soon/rr_strict_n_classes_hier.sched
+++ b/dsl/progs/soon/rr_strict_n_classes_hier.sched
@@ -1,7 +1,7 @@
 classes A, B, CU, CV, CW, CX;
 
-c_policy = rr[rr[CU, CV], strict[CW, CX]];
-policy = strict[A, B, c_policy];
+c_policy = rr[rr[(CU), (CV)], strict[(CW), (CX)]];
+policy = strict[(A), (B), c_policy];
 
 return policy
 

--- a/dsl/progs/soon/rr_strict_n_classes_hier.sched
+++ b/dsl/progs/soon/rr_strict_n_classes_hier.sched
@@ -1,7 +1,7 @@
-classes A, B, CU, CV, CW, CX
+classes A, B, CU, CV, CW, CX;
 
-c_policy = rr[rr[CU, CV], strict[CW, CX]]
-policy = strict[A, B, c_policy]
+c_policy = rr[rr[CU, CV], strict[CW, CX]];
+policy = strict[A, B, c_policy];
 
 return policy
 

--- a/dsl/progs/soon/strict_n_classes.sched
+++ b/dsl/progs/soon/strict_n_classes.sched
@@ -1,5 +1,5 @@
-classes A, B, C
+classes A, B, C;
 
-policy = strict[A, B, C]
+policy = strict[A, B, C];
 
 return policy

--- a/dsl/progs/soon/strict_n_classes.sched
+++ b/dsl/progs/soon/strict_n_classes.sched
@@ -1,5 +1,5 @@
 classes A, B, C;
 
-policy = strict[(A), (B), (C)];
+policy = strict[A, B, C];
 
 return policy

--- a/dsl/progs/soon/strict_n_classes.sched
+++ b/dsl/progs/soon/strict_n_classes.sched
@@ -1,5 +1,5 @@
 classes A, B, C;
 
-policy = strict[A, B, C];
+policy = strict[(A), (B), (C)];
 
 return policy

--- a/dsl_lang/lib/ast.ml
+++ b/dsl_lang/lib/ast.ml
@@ -23,5 +23,5 @@ type statement =
 | Seq of statement * statement
 | Ret of return
 
-type program =
-| Prog of declare * (statement list) * return
+(* type program =
+| Prog of declare * (statement list) * return *)

--- a/dsl_lang/lib/lexer.mll
+++ b/dsl_lang/lib/lexer.mll
@@ -19,8 +19,6 @@ rule token = parse
 | "="       { EQUALS }
 | "["       { LBRACE }
 | "]"       { RBRACE }
-| "("       { LPAREN }
-| ")"       { RPAREN }
 | "return"  { RETURN }
 | "classes" { CLASSES }
 | ","       { COMMA }

--- a/dsl_lang/lib/lexer.mll
+++ b/dsl_lang/lib/lexer.mll
@@ -9,14 +9,18 @@ let whitespace = [' ' '\t']+
 let id = ['a'-'z'] ['a'-'z' '0'-'9' '_']*
 let bigid = ['A'-'Z']* 
 let newline = ['\n']*
+let comment = ['/' '/'] ['A'-'Z' 'a'-'z' '0'-'9' ' ' ',' '.']* ['\x00' - '\x80']* ['\n']*
 
 
 rule token = parse
 | whitespace        { token lexbuf}
 | newline       { Lexing.new_line lexbuf; token lexbuf }
+| comment      { token lexbuf }
 | "="       { EQUALS }
 | "["       { LBRACE }
 | "]"       { RBRACE }
+| "("       { LPAREN }
+| ")"       { RPAREN }
 | "return"  { RETURN }
 | "classes" { CLASSES }
 | ","       { COMMA }

--- a/dsl_lang/lib/lexer.mll
+++ b/dsl_lang/lib/lexer.mll
@@ -9,7 +9,7 @@ let whitespace = [' ' '\t']+
 let id = ['a'-'z'] ['a'-'z' '0'-'9' '_']*
 let bigid = ['A'-'Z']* 
 let newline = ['\n']*
-let comment = ['/' '/'] ['A'-'Z' 'a'-'z' '0'-'9' ' ' ',' '.']* ['\x00' - '\x80']* ['\n']*
+let comment = ['/' '/'] ['\x00' - '\x09']* ['\x0b' - '\x80']*
 
 
 rule token = parse

--- a/dsl_lang/lib/parser.mly
+++ b/dsl_lang/lib/parser.mly
@@ -17,7 +17,6 @@
 %token SEMICOLON
 %token LPAREN
 %token RPAREN
-%token COMMENT
 
 %type <policy> policy
 %type <Ast.statement> prog
@@ -31,7 +30,7 @@ policy:
     | FIFO LBRACE; pl = arglist; RBRACE               { Fifo pl }
     | STRICT LBRACE; pl = arglist; RBRACE             { Strict pl }
     | FAIR LBRACE; pl = arglist; RBRACE               { Fair pl }
-    | LPAREN; pl = singlelist; RPAREN                              { Fifo pl }
+    | LPAREN; pl = singlelist; RPAREN                 { Fifo pl }
     | CLSS                                            { Class($1) }
     | VAR                                             { Var($1) }
 

--- a/dsl_lang/lib/parser.mly
+++ b/dsl_lang/lib/parser.mly
@@ -15,6 +15,9 @@
 %token FAIR 
 %token STRICT 
 %token SEMICOLON
+%token LPAREN
+%token RPAREN
+%token COMMENT
 
 %type <policy> policy
 %type <Ast.statement> prog
@@ -28,11 +31,15 @@ policy:
     | FIFO LBRACE; pl = arglist; RBRACE               { Fifo pl }
     | STRICT LBRACE; pl = arglist; RBRACE             { Strict pl }
     | FAIR LBRACE; pl = arglist; RBRACE               { Fair pl }
+    | LPAREN; pl = singlelist; RPAREN                              { Fifo pl }
     | CLSS                                            { Class($1) }
     | VAR                                             { Var($1) }
 
 arglist:
     | pl = separated_list(COMMA, policy)              { pl } ;
+
+singlelist:
+    | pl = policy                                     { [pl] } ;
 
 /* Statements */
 state:

--- a/dsl_lang/lib/parser.mly
+++ b/dsl_lang/lib/parser.mly
@@ -42,6 +42,7 @@ state:
 statem:
     | RETURN policy                         { Ret(Return($2)) }
     | CLASSES; vl  = list_fields            { Declare(DeclareClasses vl) }
+    | VAR EQUALS policy                     { Assignment(Assn($1, $3)) }
 
 list_fields:
     vl = separated_list(COMMA, CLSS)          { vl } ;

--- a/dsl_lang/lib/parser.mly
+++ b/dsl_lang/lib/parser.mly
@@ -15,8 +15,6 @@
 %token FAIR
 %token STRICT
 %token SEMICOLON
-%token LPAREN
-%token RPAREN
 
 %type <policy> policy
 %type <Ast.statement> prog
@@ -30,15 +28,11 @@ policy:
     | FIFO LBRACE; pl = arglist; RBRACE               { Fifo pl }
     | STRICT LBRACE; pl = arglist; RBRACE             { Strict pl }
     | FAIR LBRACE; pl = arglist; RBRACE               { Fair pl }
-    | LPAREN; pl = singlelist; RPAREN                 { Fifo pl }
     | CLSS                                            { Class($1) }
     | VAR                                             { Var($1) }
 
 arglist:
     | pl = separated_list(COMMA, policy)              { pl } ;
-
-singlelist:
-    | pl = policy                                     { [pl] } ;
 
 /* Statements */
 state:

--- a/dsl_lang/lib/q.sched
+++ b/dsl_lang/lib/q.sched
@@ -1,6 +1,0 @@
-classes B, RP, RT;
-
-r_policy = rr[fifo[RP], fifo[RT]];
-policy = rr[fifo[B], r_policy];
-
-return policy

--- a/dsl_lang/lib/q.sched
+++ b/dsl_lang/lib/q.sched
@@ -1,2 +1,6 @@
-classes CU, CV, CW, CX; 
-return rr[rr[CU, CV], strict[CW, CX]]
+classes B, RP, RT;
+
+r_policy = rr[fifo[RP], fifo[RT]];
+policy = rr[fifo[B], r_policy];
+
+return policy


### PR DESCRIPTION
This PR builds on #25. It adds variable assignment, syntactic sugar, and the ability to put comments in our DSL. To run, cd to dsl_lang, then in the command line
```
dune utop lib
```
To parse sample programs, run
```
open Dsl_core;;
Dsl_core.Util.parse_file "../dsl/progs/now/rr_2_classes.sched";;
```
A doubt I have is the definition of a program. As discussed in #27, it could be defined as
```OCaml
type program = Prog of declare * statement
``` 
or 
```OCaml
type program = Prog of declare * (statement list) * return
```
This version of the parser works on a program being defined as merely a statement. I've been trying to think over whether this is a problem or could it actually just give the interpreter a little more work, but still work fine? If the latter is true, I would rather do more work on the interpreter than wrestle with the parser. So I'm unsure which direction to go from here.