### PR TITLE
DSL: Simplify ast

### DIFF
--- a/dsl_lang/lib/ast.ml
+++ b/dsl_lang/lib/ast.ml
@@ -7,18 +7,15 @@ type declare =
 type policy =
 | Class of clss
 | Fifo of policy list
-| Fair of policy list (*same as round robin*)
+| Fair of policy list
 | Strict of policy list
 | Var of var
+
+type return =
+| Return of policy
 
 type assignment =
 | Assn of var * policy
 
-type statement =
-| Declare of declare
-| Assignment of assignment
-| Seq of statement * statement
-| Return of policy
-
 type program =
-| Prog of declare * (statement list)
+| Prog of declare * (assignment list) * return

--- a/dsl_lang/lib/parser.mly
+++ b/dsl_lang/lib/parser.mly
@@ -17,7 +17,7 @@
 %token SEMICOLON
 
 %type <policy> policy
-%type <Ast.statement> prog
+%type <Ast.program> prog
 
 %start prog
 
@@ -25,27 +25,29 @@
 
 /* Policies */
 policy:
-    | FIFO LBRACE; pl = arglist; RBRACE               { Fifo pl }
-    | STRICT LBRACE; pl = arglist; RBRACE             { Strict pl }
-    | FAIR LBRACE; pl = arglist; RBRACE               { Fair pl }
-    | CLSS                                            { Class($1) }
-    | VAR                                             { Var($1) }
-
+    | FIFO LBRACE; pl = arglist; RBRACE             { Fifo pl }
+    | STRICT LBRACE; pl = arglist; RBRACE           { Strict pl }
+    | FAIR LBRACE; pl = arglist; RBRACE             { Fair pl }
+    | CLSS                                          { Class($1) }
+    | VAR                                           { Var($1) }
 arglist:
-    | pl = separated_list(COMMA, policy)              { pl } ;
+    | pl = separated_list(COMMA, policy)            { pl } ;
 
-/* Statements */
-state:
-    | statem SEMICOLON state                           { Seq($1, $3) }
-    | statem                                           { $1 }
-
-statem:
-    | RETURN policy                         { Return($2) }
-    | CLASSES; vl  = list_fields            { Declare(DeclareClasses vl) }
-    | VAR EQUALS policy                     { Assignment(Assn($1, $3)) }
-
+/* Declarations */
+declare:
+    | CLASSES; vl  = list_fields; SEMICOLON         { DeclareClasses vl }
 list_fields:
-    vl = separated_list(COMMA, CLSS)          { vl } ;
+    vl = separated_list(COMMA, CLSS)                { vl } ;
+
+/* Return */
+return:
+    | RETURN policy                                 { Return($2) }
+
+/* Assignment List */
+assignments:
+    l = list(assignment)                            { l }
+assignment:
+    | VAR EQUALS policy SEMICOLON                   { Assn($1, $3) }
 
 /* Program */
-prog: state EOF                               { $1 }
+prog: declare assignments return EOF                { Prog($1, $2, $3) }


### PR DESCRIPTION
#27 is about to be closed, but I have a little more simplification to offer in the AST. I'd love feedback on this from all. This PR makes the changes I propose below, both in the AST and in the parser. It works correctly on all our sample programs.

However, please treat the text below and the PR itself as a proof of concept. It's not trying to be "set in stone" or prescriptive in the slightest; please do chime in with your thoughts.

At present we have:

```ocaml
type clss = string
type var = string

type declare =
| DeclareClasses of clss list

type policy =
| Class of clss
| Fifo of policy list
| Fair of policy list
| Strict of policy list
| Var of var

type assignment =
| Assn of var * policy

type statement =
| Declare of declare
| Assignment of assignment
| Seq of statement * statement
| Return of policy

type program =
| Prog of declare * (statement list)
```

Since we have a statement _list_, we don't really need a `Seq` constructor in `statement`. We just need to actually parse a list of statements as a list, not a `Seq`. If we take on that responsibility, our AST gets to be a little simpler:
```ocaml
type statement =
| Declare of declare
| Assignment of assignment
(* | Seq of statement * statement *)
| Return of policy

type program =
| Prog of declare * (statement list)
```

We should probably also drop the `| Declare of declare` constructor from `statement`, so that the user gets one and only once chance to declare their classes up top. That gets us to:
```ocaml
type declare =
| DeclareClasses of clss list

...

type statement =
(* | Declare of declare *)
| Assignment of assignment
(* | Seq of statement * statement *)
| Return of policy

type program =
| Prog of declare * (statement list)
```

In the same spirit you may want to drag `return` out into its own type, such that the user can only have one `return` at the end of the program.
```ocaml
type declare =
| DeclareClasses of clss list

type return = 
| Return of policy

...

type statement =
(* | Declare of declare *)
| Assignment of assignment
(* | Seq of statement * statement *)
(* | Return of policy *)

type program =
| Prog of declare * (statement list) * return
```

And now you observe that `statement` is nothing more than a silly wrapper for `Assignment`, so why not just change `statement list` into `assignment list` and be done with it?

```ocaml
type clss = string
type var = string

type declare =
| DeclareClasses of clss list

type policy =
| Class of clss
| Fifo of policy list
| Fair of policy list
| Strict of policy list
| Var of var

type return = 
| Return of policy

type assignment =
| Assn of var * policy

type program =
| Prog of declare * (assignment list) * return
```
