### PR TITLE
Flatten all the way through, and simplify a helper

### DIFF
--- a/dsl_lang/bin/dune
+++ b/dsl_lang/bin/dune
@@ -1,4 +1,3 @@
 (executable
  (name main)
  (libraries dsl_core ounit2))
-

--- a/dsl_lang/bin/main.ml
+++ b/dsl_lang/bin/main.ml
@@ -13,7 +13,7 @@ let make_test (name : string) (filename : string) (val_str : string) =
     (Util.string_of_policy (eval_prog filename))
     ~printer:(fun x -> x)
 
-let make_error_test (name : string) (filename : string) (exn : exn ) =
+let make_error_test (name : string) (filename : string) (exn : exn) =
   name >:: fun _ ->
   assert_raises exn (fun () ->
       try Util.string_of_policy (eval_prog filename)
@@ -37,8 +37,7 @@ let tests =
     make_test "3 classes with substitutions"
       "../../dsl/progs/soon/rr_n_class_hier.sched"
       "rr[A, B, rr[rr[CU, CV], rr[CW, CX]]]";
-    make_test "rr of 3" "../../dsl/progs/soon/rr_n_classes.sched"
-      "rr[A, B, C]";
+    make_test "rr of 3" "../../dsl/progs/soon/rr_n_classes.sched" "rr[A, B, C]";
     make_test "rr and strict substitutions"
       "../../dsl/progs/soon/rr_strict_n_classes_hier.sched"
       "strict[A, B, rr[rr[CU, CV], strict[CW, CX]]]";
@@ -49,11 +48,13 @@ let tests =
 let error_tests =
   [
     make_error_test "undeclared class"
-      "../../dsl/progs/incorrect/undeclared_classes.sched" (Eval.UnboundVariable "...");
+      "../../dsl/progs/incorrect/undeclared_classes.sched"
+      (Eval.UnboundVariable "...");
     make_error_test "unbound variable"
       "../../dsl/progs/incorrect/unbound_var.sched" (Eval.UnboundVariable "...");
     make_error_test "unbound var in middle of list of assignments"
-      "../../dsl/progs/incorrect/unbound_var_hier.sched" (Eval.UnboundVariable "...");
+      "../../dsl/progs/incorrect/unbound_var_hier.sched"
+      (Eval.UnboundVariable "...");
   ]
 
 let suite = "suite" >::: tests @ error_tests

--- a/dsl_lang/lib/ast.ml
+++ b/dsl_lang/lib/ast.ml
@@ -4,7 +4,7 @@ type var = string
 type policy =
   | Class of clss
   | Fifo of policy list
-  | Fair of policy list
+  | RoundRobin of policy list
   | Strict of policy list
   | Var of var
 

--- a/dsl_lang/lib/eval.ml
+++ b/dsl_lang/lib/eval.ml
@@ -50,16 +50,13 @@ let rec eval_assn (alist : assignment list) (st : store) (cl : classes) : store
       let st' = update st var pol in
       eval_assn t st' cl
 
-(* First funtion called by eval. Matches against the components of type program
+(* First funtion called by eval. Unpacks the components of type program
    and further calls helper functions to check each component of a program. *)
 let eval_helper (prog : program) (st : store) (cl : classes) : policy =
-  match prog with
-  | (dec, alist, ret) -> (
-      match dec with
-      | clist -> (
-          let cl' = cl @ clist in
-          let st' = eval_assn alist st cl' in
-          match ret with p -> eval_pol p st' cl'))
+  let dec, alist, ret = prog in
+  let cl' = cl @ dec in
+  let st' = eval_assn alist st cl' in
+  eval_pol ret st' cl'
 
 (* Outermost function that is called by main.ml *)
 let eval (p : program) : policy = eval_helper p [] []

--- a/dsl_lang/lib/eval.ml
+++ b/dsl_lang/lib/eval.ml
@@ -36,7 +36,7 @@ and eval_pol (p : policy) (st : store) (cl : classes) : policy =
       let pol = lookup st x in
       eval_pol pol st cl
   | Fifo (h :: t) -> Fifo (eval_pol h st cl :: evalplist t st cl)
-  | Fair (h :: t) -> Fair (eval_pol h st cl :: evalplist t st cl)
+  | RoundRobin (h :: t) -> RoundRobin (eval_pol h st cl :: evalplist t st cl)
   | Strict (h :: t) -> Strict (eval_pol h st cl :: evalplist t st cl)
   | _ -> failwith "cannot have empty policy"
 
@@ -46,7 +46,7 @@ let rec eval_assn (alist : assignment list) (st : store) (cl : classes) : store
     =
   match alist with
   | [] -> st
-  | Assn (var, pol) :: t ->
+  | (var, pol) :: t ->
       let st' = update st var pol in
       eval_assn t st' cl
 
@@ -54,12 +54,12 @@ let rec eval_assn (alist : assignment list) (st : store) (cl : classes) : store
    and further calls helper functions to check each component of a program. *)
 let eval_helper (prog : program) (st : store) (cl : classes) : policy =
   match prog with
-  | Prog (dec, alist, ret) -> (
+  | (dec, alist, ret) -> (
       match dec with
-      | DeclareClasses clist -> (
+      | clist -> (
           let cl' = cl @ clist in
           let st' = eval_assn alist st cl' in
-          match ret with Return p -> eval_pol p st' cl'))
+          match ret with p -> eval_pol p st' cl'))
 
 (* Outermost function that is called by main.ml *)
 let eval (p : program) : policy = eval_helper p [] []

--- a/dsl_lang/lib/util.ml
+++ b/dsl_lang/lib/util.ml
@@ -5,15 +5,15 @@ exception ParserError of string
 let rec string_of_plist (plist : Ast.policy list) : string =
   match plist with
   | [] -> ""
-  | [x] -> string_of_policy x
+  | [ x ] -> string_of_policy x
   | h :: t -> string_of_policy h ^ ", " ^ string_of_plist t
 
 (** Takes a policy and returns the string representation of it. **)
-and
-string_of_policy (pol : Ast.policy) : string =
+and string_of_policy (pol : Ast.policy) : string =
   match pol with
   | Class c -> c
   | Fifo pl -> "fifo[" ^ string_of_plist pl ^ "]"
   | Strict pl -> "strict[" ^ string_of_plist pl ^ "]"
   | RoundRobin pl -> "rr[" ^ string_of_plist pl ^ "]"
   | Var v -> v
+  | _ -> "NWC pretty-printing not yet implemented"

--- a/dsl_lang/lib/util.ml
+++ b/dsl_lang/lib/util.ml
@@ -36,10 +36,11 @@ let rec string_of_plist (plist : Ast.policy list) : string =
   | h :: t -> string_of_policy h ^ ", " ^ string_of_plist t
 
 (** Takes a policy and returns the string representation of it. **)
-and string_of_policy (pol : Ast.policy) : string =
+and
+string_of_policy (pol : Ast.policy) : string =
   match pol with
   | Class c -> c
-    | Fifo pl -> "fifo[" ^ string_of_plist pl ^ "]"
-    | Strict pl -> "strict[" ^ string_of_plist pl ^ "]"
-    | RoundRobin pl -> "rr[" ^ string_of_plist pl ^ "]"
-    | Var v -> v
+  | Fifo pl -> "fifo[" ^ string_of_plist pl ^ "]"
+  | Strict pl -> "strict[" ^ string_of_plist pl ^ "]"
+  | RoundRobin pl -> "rr[" ^ string_of_plist pl ^ "]"
+  | Var v -> v

--- a/dsl_lang/lib/util.ml
+++ b/dsl_lang/lib/util.ml
@@ -1,6 +1,31 @@
 exception NonTerminal
 exception ParserError of string
 
+(** syntax_error_msg lexbuf is a syntax error message for the current position **)
+let syntax_error_msg lexbuf =
+  let pos = Lexing.lexeme_start_p lexbuf in
+  let lnum, cnum = (pos.pos_lnum, pos.pos_cnum - pos.pos_bol) in
+  Printf.sprintf "Syntax error at line %d, character %d" lnum cnum
+
+let parse lexbuf = Parser.prog Lexer.token lexbuf
+
+(** parse s parses a program string into an AST **)
+let parse_string (s : string) =
+  let lexbuf = Lexing.from_string s in
+  try parse lexbuf
+  with Parser.Error -> raise (ParserError (syntax_error_msg lexbuf))
+
+(** parse s parses a program file into an AST **)
+let parse_file (f : string) =
+  let lexbuf = Lexing.from_channel (open_in f) in
+  try parse lexbuf with
+  | Parser.Error ->
+      prerr_endline (syntax_error_msg lexbuf);
+      exit 1
+  | Lexer.Err ->
+      prerr_endline (syntax_error_msg lexbuf);
+      exit 1
+
 (** Helper function to turn policy lists into strings. **)
 let rec string_of_plist (plist : Ast.policy list) : string =
   match plist with

--- a/dsl_lang/lib/util.ml
+++ b/dsl_lang/lib/util.ml
@@ -39,13 +39,7 @@ let rec string_of_plist (plist : Ast.policy list) : string =
 and string_of_policy (pol : Ast.policy) : string =
   match pol with
   | Class c -> c
-  | Fifo [x] -> "fifo[" ^ string_of_policy x ^ "]"
-  | Strict [x] -> "strict[" ^ string_of_policy x ^ "]"
-  | Fair [x] -> "rr[" ^ string_of_policy x ^ "]"
-  | Fifo (h :: t) ->
-      "fifo[" ^ string_of_policy h ^ ", " ^ string_of_plist t ^ "]"
-  | Strict (h :: t) ->
-      "strict[" ^ string_of_policy h ^ ", " ^ string_of_plist t ^ "]"
-  | Fair (h :: t) ->
-      "rr[" ^ string_of_policy h ^ ", " ^ string_of_plist t ^ "]"
-  | _ -> "error"
+    | Fifo pl -> "fifo[" ^ string_of_plist pl ^ "]"
+    | Strict pl -> "strict[" ^ string_of_plist pl ^ "]"
+    | RoundRobin pl -> "rr[" ^ string_of_plist pl ^ "]"
+    | Var v -> v


### PR DESCRIPTION
This is a quick little PR that picks up a loose thread and simplifies a helper.

1. We flattened the AST and massaged away ADTs that only had one constructor, but this also meant that we needed to stop expecting those constructors and just expect the payloads instead. Maybe that had already been done but had gone away during a merge.
2. I found a way to simplify a piece of OCaml but I realized this a little too late and the relevant PR (#37) had already closed!