### PR TITLE
Prohibit duplicate classes

### DIFF
--- a/dsl/lib/policy.ml
+++ b/dsl/lib/policy.ml
@@ -53,8 +53,9 @@ let rec eval cl st (used : string list ref) p =
       TokenBucket (eval_plst cl st used plst, n1, n2)
   | Ast.StopAndGo (plst, n) -> StopAndGo (eval_plst cl st used plst, n)
 
-(* Evaluates a program, looking up any variables and substituting them in. *)
-let from_program (cl, alst, ret) = eval cl alst (ref []) ret
+(* Evaluates a program, looking up any variables and substituting them in. It returns
+   the final policy with any variables substituted in. *)
+let from_program (cl, alst, ret) : t = eval cl alst (ref []) ret
 
 let rec to_string p =
   let bracket_wrap s = "[" ^ s ^ "]" in

--- a/dsl/lib/policy.mli
+++ b/dsl/lib/policy.mli
@@ -15,6 +15,7 @@ type t =
 
 exception UnboundVariable of Ast.var
 exception UndeclaredClass of Ast.clss
+exception DuplicateClass of Ast.clss
 
 val from_program : Ast.program -> t
 val to_string : t -> string

--- a/dsl/test/well_formed.ml
+++ b/dsl/test/well_formed.ml
@@ -1,7 +1,7 @@
 open Dsl_core
 open OUnit2
 
-let path_prefix = "../../../../progs/"
+let path_prefix = "../../progs/"
 
 let parse (filename : string) =
   path_prefix ^ filename |> Parse.parse_file |> Policy.from_program
@@ -58,6 +58,8 @@ let error_tests =
       (Policy.UnboundVariable "policy");
     make_error_test "unbound var in middle of list of assignments"
       "incorrect/unbound_var_hier.sched" (Policy.UnboundVariable "r_polic");
+    make_error_test "class used twice in policy" "incorrect/duplicate_classes.sched" 
+    (Policy.DuplicateClass "B"); 
   ]
 
 let suite = "suite" >::: tests @ error_tests

--- a/dsl/test/well_formed.ml
+++ b/dsl/test/well_formed.ml
@@ -62,6 +62,8 @@ let error_tests =
       "incorrect/unbound_var_hier.sched" (Policy.UnboundVariable "r_polic");
     make_error_test "class used twice in policy"
       "incorrect/duplicate_classes.sched" (Policy.DuplicateClass "B");
+    make_error_test "class used twice in one fifo"
+      "incorrect/duplicate_samepol.sched" (Policy.DuplicateClass "A");
   ]
 
 let suite = "suite" >::: tests @ error_tests

--- a/dsl/test/well_formed.ml
+++ b/dsl/test/well_formed.ml
@@ -1,7 +1,7 @@
 open Dsl_core
 open OUnit2
 
-let path_prefix = "../../progs/"
+let path_prefix = "../../../../progs/"
 
 let parse (filename : string) =
   path_prefix ^ filename |> Parse.parse_file |> Policy.from_program
@@ -48,6 +48,8 @@ let tests =
        width = 5]";
     make_test "rcsp for 4 classes" "non_work_conserving/rcsp_4_classes.sched"
       "rcsp[A, B, C, D]";
+    make_test "unused variable where class is duplicated"
+      "incorrect/unused_variable.sched" "strict[rr[A, B], C]";
   ]
 
 let error_tests =
@@ -58,8 +60,8 @@ let error_tests =
       (Policy.UnboundVariable "policy");
     make_error_test "unbound var in middle of list of assignments"
       "incorrect/unbound_var_hier.sched" (Policy.UnboundVariable "r_polic");
-    make_error_test "class used twice in policy" "incorrect/duplicate_classes.sched" 
-    (Policy.DuplicateClass "B"); 
+    make_error_test "class used twice in policy"
+      "incorrect/duplicate_classes.sched" (Policy.DuplicateClass "B");
   ]
 
 let suite = "suite" >::: tests @ error_tests

--- a/progs/incorrect/duplicate_classes.sched
+++ b/progs/incorrect/duplicate_classes.sched
@@ -1,0 +1,6 @@
+classes A, B; 
+
+var = rr[A, B];
+final = fifo[var, B];
+
+return final

--- a/progs/incorrect/duplicate_classes.sched
+++ b/progs/incorrect/duplicate_classes.sched
@@ -1,6 +1,6 @@
 classes A, B; 
 
 var = rr[A, B];
-final = fifo[var, B];
+final = fifo[var, B]; // B is used twice
 
 return final

--- a/progs/incorrect/duplicate_samepol.sched
+++ b/progs/incorrect/duplicate_samepol.sched
@@ -1,0 +1,5 @@
+classes A, B;
+
+x = fifo[A, A];
+
+return x

--- a/progs/incorrect/unused_variable.sched
+++ b/progs/incorrect/unused_variable.sched
@@ -1,0 +1,7 @@
+classes A, B, C;
+
+pol_1 = rr[A, B];
+pol_2 = rr[B, C];
+ans = strict[pol_1, C];
+
+return ans


### PR DESCRIPTION
This PR makes progress towards #40. It throws the error `DuplicateClass` when a class is used more than once in a program. The next step is to throw an error when there is an unused variable.