### PR TITLE
Add Union Operator; Update AST

### DIFF
--- a/progs/incorrect/duplicate_classes.sched
+++ b/progs/incorrect/duplicate_classes.sched
@@ -1,6 +1,6 @@
 classes A, B; 
 
-var = rr[A, B];
-final = fifo[var, B]; // B is used twice
+var = fifo[union[A, B]];
+final = rr[var, fifo[B]]; // B is used twice
 
 return final

--- a/progs/incorrect/duplicate_samepol.sched
+++ b/progs/incorrect/duplicate_samepol.sched
@@ -1,5 +1,5 @@
 classes A, B;
 
-x = fifo[A, A];
+x = fifo[union[A, A]];
 
 return x

--- a/progs/incorrect/set_hierarchical.sched
+++ b/progs/incorrect/set_hierarchical.sched
@@ -1,0 +1,5 @@
+classes A, B;
+
+combined = rr[union[A, B]];
+
+return combined

--- a/progs/incorrect/set_multiple.sched
+++ b/progs/incorrect/set_multiple.sched
@@ -1,5 +1,6 @@
 classes A, B;
 
+//FIFO cannot be applied to multiple classes; they must be unioned first.
 combined = fifo[A, B];
 
 return combined

--- a/progs/incorrect/set_multiple.sched
+++ b/progs/incorrect/set_multiple.sched
@@ -1,0 +1,5 @@
+classes A, B;
+
+combined = fifo[A, B];
+
+return combined

--- a/progs/incorrect/unbound_var.sched
+++ b/progs/incorrect/unbound_var.sched
@@ -1,5 +1,5 @@
 classes X, Y, Z;
 
-foo = strict[X, Y, Z];
+foo = strict[fifo[X], fifo[Y], fifo[Z]];
 
 return policy // user probably meant to return `foo`

--- a/progs/incorrect/unbound_var_hier.sched
+++ b/progs/incorrect/unbound_var_hier.sched
@@ -1,7 +1,7 @@
 classes BX, BY, RP, RT;
 
-b_policy = fifo[BX, BY];
-r_policy = rr[RP, RT];
+b_policy = fifo[union[BX, BY]];
+r_policy = rr[fifo[RP], fifo[RT]];
 policy = rr[b_policy, r_polic]; // user made a typo, meant to reference `r_policy`
 
 return policy

--- a/progs/incorrect/undeclared_classes.sched
+++ b/progs/incorrect/undeclared_classes.sched
@@ -1,5 +1,5 @@
 classes X, Y;
 
-pol = strict[X, Z]; // `Z` is undeclared, only `X` and `Y` may be used
+pol = strict[fifo[X], fifo[Z]]; // `Z` is undeclared, only `X` and `Y` may be used
 
 return pol

--- a/progs/incorrect/unused_variable.sched
+++ b/progs/incorrect/unused_variable.sched
@@ -1,7 +1,7 @@
 classes A, B, C;
 
-pol_1 = rr[A, B];
-pol_2 = rr[B, C];
-ans = strict[pol_1, C];
+pol_1 = rr[fifo[A], fifo[B]];
+pol_2 = rr[fifo[B], fifo[C]];
+ans = strict[pol_1, fifo[C]];
 
 return ans

--- a/progs/non_work_conserving/leaky_2_classes.sched
+++ b/progs/non_work_conserving/leaky_2_classes.sched
@@ -1,9 +1,8 @@
 classes A, B;
 
-policy = leakybucket [[A, B], width=5, buffer=10];
+policy = leakybucket [[fifo[A], fifo[B]], width=5, buffer=10];
 // Interleave packets from flows A and B, allowing at most 
 // 5 packets to be processed per time cycle,
 // and at most 10 packets to be in a buffer at once
 
 return policy
-    

--- a/progs/non_work_conserving/rcsp_4_classes.sched
+++ b/progs/non_work_conserving/rcsp_4_classes.sched
@@ -1,5 +1,5 @@
 classes A, B, C, D;
 
-policy = rcsp [A, B, C, D];
+policy = rcsp [fifo[A], fifo[B], fifo[C], fifo[D]];
 
 return policy

--- a/progs/non_work_conserving/sg_3_classes.sched
+++ b/progs/non_work_conserving/sg_3_classes.sched
@@ -1,7 +1,7 @@
 classes A, B, C;
 
-sub_policy1 = stopandgo[[A, B], width=10];
-sub_policy2 = stopandgo[[C], width=10];
+sub_policy1 = stopandgo[[fifo[A], fifo[B]], width=10];
+sub_policy2 = stopandgo[[fifo[C]], width=10];
 policy = stopandgo [[sub_policy1, sub_policy2], width=5];
 
 //Interleaves two sub-policies, with windows of length 10,

--- a/progs/non_work_conserving/token_2_rr_children.sched
+++ b/progs/non_work_conserving/token_2_rr_children.sched
@@ -1,7 +1,7 @@
 classes A, B, C, D;
 
-sub1 = rr [A, B];
-sub2 = rr [C, D];
+sub1 = rr [fifo[A], fifo[B]];
+sub2 = rr [fifo[C], fifo[D]];
 
 policy = tokenbucket [[sub1, sub2], width=20, time=50];
 

--- a/progs/work_conserving/drop_a_class.sched
+++ b/progs/work_conserving/drop_a_class.sched
@@ -1,6 +1,6 @@
 classes A, B;
 
-policy = A;
+policy = fifo[A];
 
 return policy
 

--- a/progs/work_conserving/fifo_1_class.sched
+++ b/progs/work_conserving/fifo_1_class.sched
@@ -1,5 +1,5 @@
 classes A;
 
-policy = A;
+policy = fifo[A];
 
 return policy

--- a/progs/work_conserving/fifo_1_class_sugar.sched
+++ b/progs/work_conserving/fifo_1_class_sugar.sched
@@ -1,6 +1,6 @@
 classes A;
 
-policy = A;
+policy = fifo[A];
 // Sample test comment
 
 return policy

--- a/progs/work_conserving/fifo_2_class_union.sched
+++ b/progs/work_conserving/fifo_2_class_union.sched
@@ -1,0 +1,6 @@
+classes A, B;
+
+policy = A;
+policy2 = union[A, B];
+
+return policy2

--- a/progs/work_conserving/fifo_2_class_union.sched
+++ b/progs/work_conserving/fifo_2_class_union.sched
@@ -1,5 +1,5 @@
 classes A, B;
 
-policy = union[A, B];
+policy = fifo[union[A, B]];
 
 return policy

--- a/progs/work_conserving/fifo_2_class_union.sched
+++ b/progs/work_conserving/fifo_2_class_union.sched
@@ -1,6 +1,5 @@
 classes A, B;
 
-policy = A;
-policy2 = union[A, B];
+policy = union[A, B];
 
-return policy2
+return policy

--- a/progs/work_conserving/fifo_n_classes.sched
+++ b/progs/work_conserving/fifo_n_classes.sched
@@ -1,5 +1,5 @@
 classes A, B, C;
 
-policy = fifo[A, B, C];
+policy = fifo[union[A, B, C]];
 
 return policy

--- a/progs/work_conserving/rr_1_class.sched
+++ b/progs/work_conserving/rr_1_class.sched
@@ -1,5 +1,5 @@
 classes A;
 
-policy = rr[A];
+policy = rr[fifo[A]];
 
 return policy

--- a/progs/work_conserving/rr_2_classes.sched
+++ b/progs/work_conserving/rr_2_classes.sched
@@ -1,5 +1,5 @@
 classes A, B;
 
-policy = rr[A, B];
+policy = rr[fifo[union[A, B]]];
 
 return policy

--- a/progs/work_conserving/rr_hier.sched
+++ b/progs/work_conserving/rr_hier.sched
@@ -4,8 +4,8 @@ classes B, RP, RT;
 // RP packets are destined for Pittsburgh
 // RT packets are destined for Toronto
 
-r_policy = rr[RP, RT];
-policy = rr[B, r_policy];
+r_policy = rr[fifo[RP], fifo[RT]];
+policy = rr[fifo[B], r_policy];
 
 return policy
 

--- a/progs/work_conserving/rr_hier_merge_sugar.sched
+++ b/progs/work_conserving/rr_hier_merge_sugar.sched
@@ -6,8 +6,8 @@ classes BX, BY, RP, RT;
 // RP packets are destined for Pittsburgh
 // RT packets are destined for Toronto
 
-b_policy = fifo[BX, BY];
-r_policy = rr[RP, RT];
+b_policy = fifo[union[BX, BY]];
+r_policy = rr[fifo[RP], fifo[RT]];
 policy = rr[b_policy, r_policy];
 
 return policy

--- a/progs/work_conserving/rr_hier_sugar.sched
+++ b/progs/work_conserving/rr_hier_sugar.sched
@@ -4,8 +4,8 @@ classes B, RP, RT;
 // RP packets are destined for Pittsburgh
 // RT packets are destined for Toronto
 
-r_policy = rr[RP, RT];
-policy = rr[B, r_policy];
+r_policy = rr[fifo[RP], fifo[RT]];
+policy = rr[fifo[B], r_policy];
 
 return policy
 

--- a/progs/work_conserving/rr_n_class_hier.sched
+++ b/progs/work_conserving/rr_n_class_hier.sched
@@ -1,7 +1,7 @@
 classes A, B, CU, CV, CW, CX;
 
-c_policy = rr[rr[CU, CV], rr[CW, CX]];
-policy = rr[A, B, c_policy];
+c_policy = rr[rr[fifo[CU], fifo[CV]], rr[fifo[CW], fifo[CX]]];
+policy = rr[fifo[A], fifo[B], c_policy];
 
 return policy
 

--- a/progs/work_conserving/rr_n_classes.sched
+++ b/progs/work_conserving/rr_n_classes.sched
@@ -1,5 +1,5 @@
 classes A, B, C;
 
-policy = rr[A, B, C];
+policy = rr[fifo[A], fifo[B], fifo[C]];
 
 return policy

--- a/progs/work_conserving/rr_strict_n_classes_hier.sched
+++ b/progs/work_conserving/rr_strict_n_classes_hier.sched
@@ -1,7 +1,7 @@
 classes A, B, CU, CV, CW, CX;
 
-c_policy = rr[rr[CU, CV], strict[CW, CX]];
-policy = strict[A, B, c_policy];
+c_policy = rr[rr[fifo[CU], fifo[CV]], strict[fifo[CW], fifo[CX]]];
+policy = strict[fifo[A], fifo[B], c_policy];
 
 return policy
 

--- a/progs/work_conserving/strict_n_classes.sched
+++ b/progs/work_conserving/strict_n_classes.sched
@@ -1,5 +1,5 @@
 classes A, B, C;
 
-policy = strict[C, B, A];
+policy = strict[fifo[C], fifo[B], fifo[A]];
 
 return policy

--- a/progs/work_conserving/wfq_n_classes.sched
+++ b/progs/work_conserving/wfq_n_classes.sched
@@ -1,5 +1,5 @@
 classes A, B, C;
 
-policy = wfq[(A, 0.1), (B, 0.2), (C, 0.3)];
+policy = wfq[fifo[A], fifo[B], fifo[C]][1, 2, 3];
 
 return policy

--- a/progs/work_conserving/wfq_n_classes.sched
+++ b/progs/work_conserving/wfq_n_classes.sched
@@ -1,5 +1,5 @@
 classes A, B, C;
 
-policy = wfq[fifo[A], fifo[B], fifo[C]][1, 2, 3];
+policy = wfq[(fifo[A], 1), (fifo[B], 2), (fifo[C], 3)];
 
 return policy

--- a/rio/frontend/ast.ml
+++ b/rio/frontend/ast.ml
@@ -4,6 +4,7 @@ type var = string
 (* Changes to this type must also be reflected in `Policy.t` in policy.ml *)
 type policy =
   | Class of clss
+  | Union of policy list
   | Fifo of policy list
   | RoundRobin of policy list
   | Strict of policy list

--- a/rio/frontend/ast.ml
+++ b/rio/frontend/ast.ml
@@ -15,7 +15,7 @@ type stream =
   (* Stream-To-Stream *)
   | RoundRobin of stream list
   | Strict of stream list
-  | WeightedFair of stream list * int list
+  | WeightedFair of (stream * int) list
   (* Non-Work Conserving *)
   | RateControlled of stream list
   | LeakyBucket of stream list * int * int

--- a/rio/frontend/ast.ml
+++ b/rio/frontend/ast.ml
@@ -8,14 +8,14 @@ type set =
 
 type stream =
   (* Set-to-Stream *)
-  | Fifo of set list
-  | EarliestDeadline of set list
-  | ShortestJobNext of set list
-  | ShortestRemaining of set list
+  | Fifo of set
+  | EarliestDeadline of set
+  | ShortestJobNext of set
+  | ShortestRemaining of set
   (* Stream-To-Stream *)
   | RoundRobin of stream list
   | Strict of stream list
-  | WeightedFair of (stream * float) list
+  | WeightedFair of stream list * int list
   (* Non-Work Conserving *)
   | RateControlled of stream list
   | LeakyBucket of stream list * int * int
@@ -24,7 +24,8 @@ type stream =
   (* Variables *)
   | Var of var
 
+type policy = stream
 type declare = clss list
-type assignment = var * stream
-type return = stream
+type assignment = var * policy
+type return = policy
 type program = declare * assignment list * return

--- a/rio/frontend/ast.ml
+++ b/rio/frontend/ast.ml
@@ -2,23 +2,29 @@ type clss = string
 type var = string
 
 (* Changes to this type must also be reflected in `Policy.t` in policy.ml *)
-type policy =
+type set =
   | Class of clss
-  | Union of policy list
-  | Fifo of policy list
-  | RoundRobin of policy list
-  | Strict of policy list
-  | WeightedFair of (policy * float) list
-  | EarliestDeadline of policy list
-  | ShortestJobNext of policy list
-  | ShortestRemaining of policy list
-  | RateControlled of policy list
-  | LeakyBucket of policy list * int * int
-  | TokenBucket of policy list * int * int
-  | StopAndGo of policy list * int
+  | Union of set list
+
+type stream =
+  (* Set-to-Stream *)
+  | Fifo of set list
+  | EarliestDeadline of set list
+  | ShortestJobNext of set list
+  | ShortestRemaining of set list
+  (* Stream-To-Stream *)
+  | RoundRobin of stream list
+  | Strict of stream list
+  | WeightedFair of (stream * float) list
+  (* Non-Work Conserving *)
+  | RateControlled of stream list
+  | LeakyBucket of stream list * int * int
+  | TokenBucket of stream list * int * int
+  | StopAndGo of stream list * int
+  (* Variables *)
   | Var of var
 
 type declare = clss list
-type assignment = var * policy
-type return = policy
+type assignment = var * stream
+type return = stream
 type program = declare * assignment list * return

--- a/rio/frontend/lexer.mll
+++ b/rio/frontend/lexer.mll
@@ -16,8 +16,6 @@ rule token = parse
 | "="                   { EQUALS }
 | "["                   { LBRACKET }
 | "]"                   { RBRACKET }
-| "("                   { LPAREN }
-| ")"                   { RPAREN }
 | "return"              { RETURN }
 | "classes"             { CLASSES }
 | "union"               { UNION }
@@ -41,7 +39,6 @@ rule token = parse
 | id as v               { VAR(v) }
 | bigid as i            { CLSS(i) }
 | int                   { INT (int_of_string (Lexing.lexeme lexbuf)) }
-| float                 { FLOAT (float_of_string (Lexing.lexeme lexbuf)) }
 | eof                   { EOF }
 
 

--- a/rio/frontend/lexer.mll
+++ b/rio/frontend/lexer.mll
@@ -16,6 +16,8 @@ rule token = parse
 | "="                   { EQUALS }
 | "["                   { LBRACKET }
 | "]"                   { RBRACKET }
+| "("                   { LPAREN }
+| ")"                   { RPAREN }
 | "return"              { RETURN }
 | "classes"             { CLASSES }
 | "union"               { UNION }

--- a/rio/frontend/lexer.mll
+++ b/rio/frontend/lexer.mll
@@ -20,6 +20,7 @@ rule token = parse
 | ")"                   { RPAREN }
 | "return"              { RETURN }
 | "classes"             { CLASSES }
+| "union"               { UNION }
 | "width"               { WIDTH }
 | "buffer"              { BUFFER }
 | "time"                { TIME }

--- a/rio/frontend/parser.mly
+++ b/rio/frontend/parser.mly
@@ -38,6 +38,8 @@
 %token EQUALS
 %token LBRACKET
 %token RBRACKET
+%token LPAREN
+%token RPAREN
 %token RETURN
 %token CLASSES
 %token UNION
@@ -71,14 +73,14 @@ set:
 
 /* Policies */
 policy:
-    | FIFO LBRACKET; pl = set; RBRACKET                                              { Fifo pl }
-    | EDF LBRACKET; pl = set; RBRACKET                                               { EarliestDeadline pl }
-    | SJN LBRACKET; pl = set; RBRACKET                                               { ShortestJobNext pl }
-    | SRTF LBRACKET; pl = set; RBRACKET                                              { ShortestRemaining pl }
-    | RR LBRACKET; pl = arglist; RBRACKET                                            { RoundRobin pl }
-    | STRICT LBRACKET; pl = arglist; RBRACKET                                        { Strict pl }
-    | WFQ LBRACKET; pl = arglist; RBRACKET; LBRACKET; wt = weight_list; RBRACKET     { WeightedFair (pl, wt) }
-    | RCSP LBRACKET; pl = arglist; RBRACKET                                          { RateControlled pl }
+    | FIFO LBRACKET; pl = set; RBRACKET                 { Fifo pl }
+    | EDF LBRACKET; pl = set; RBRACKET                  { EarliestDeadline pl }
+    | SJN LBRACKET; pl = set; RBRACKET                  { ShortestJobNext pl }
+    | SRTF LBRACKET; pl = set; RBRACKET                 { ShortestRemaining pl }
+    | RR LBRACKET; pl = arglist; RBRACKET               { RoundRobin pl }
+    | STRICT LBRACKET; pl = arglist; RBRACKET           { Strict pl }
+    | WFQ LBRACKET; pl = weighted_arglist; RBRACKET     { WeightedFair pl }
+    | RCSP LBRACKET; pl = arglist; RBRACKET             { RateControlled pl }
 
     | LEAKY LBRACKET; LBRACKET;
         pl = arglist; RBRACKET; COMMA;
@@ -99,8 +101,10 @@ setlist:
     | pl = separated_list(COMMA, set)               { pl }
 arglist:
     | pl = separated_list(COMMA, policy)            { pl }
-weight_list:
-    | pl = separated_list(COMMA, INT)               { pl }
+weighted_arglist:
+    | pl = separated_list(COMMA, weighted_arg)      { pl }
+weighted_arg:
+    | LPAREN; arg = separated_pair(policy, COMMA, INT); RPAREN      { arg }
 
 /* Declarations, assignments and returns */
 internalcomp :

--- a/rio/frontend/parser.mly
+++ b/rio/frontend/parser.mly
@@ -43,6 +43,7 @@
 %token RPAREN
 %token RETURN
 %token CLASSES
+%token UNION
 %token COMMA
 %token SEMICOLON
 %token EOF
@@ -69,6 +70,7 @@
 
 /* Policies */
 policy:
+    | UNION LBRACKET; pl = arglist; RBRACKET            { Union pl }
     | FIFO LBRACKET; pl = arglist; RBRACKET             { Fifo pl }
     | STRICT LBRACKET; pl = arglist; RBRACKET           { Strict pl }
     | RR LBRACKET; pl = arglist; RBRACKET               { RoundRobin pl }

--- a/rio/frontend/policy.ml
+++ b/rio/frontend/policy.ml
@@ -1,10 +1,16 @@
 (* Changes to this type must also be reflected in `Ast.policy` in ast.ml *)
-type t =
+type set =
   | Class of Ast.clss
-  | Fifo of t list
+  | Union of set list
+
+type t =
+  | Fifo of set
+  | EarliestDeadline of set
+  | ShortestJobNext of set
+  | ShortestRemaining of set
   | RoundRobin of t list
   | Strict of t list
-  | WeightedFair of (t * float) list
+  | WeightedFair of t list * int list
 
 exception UnboundVariable of Ast.var
 exception UndeclaredClass of Ast.clss
@@ -15,44 +21,56 @@ let lookup s x =
   | Some v -> v
   | None -> raise (UnboundVariable x)
 
-let rec sub cl st (p : Ast.policy) used =
-  let sub_plst cl st = List.map (fun x -> sub cl st x used) in
-  let sub_weighted_plst cl st =
-    List.map (fun (x, i) -> (sub cl st x used, i))
-  in
+let rec sub_set cl (p : Ast.set) used : set =
+  let sub_slst = List.map (fun x -> sub_set cl x used) in
 
   match p with
   | Class c ->
       if List.mem c !used then raise (DuplicateClass c)
       else if List.mem c cl then (
         used := c :: !used;
-        (Class c : t))
+        (Class c : set))
       else raise (UndeclaredClass c)
+  | Union clst -> Union (sub_slst clst)
+
+let rec sub cl st (p : Ast.policy) used =
+  let sub_plst cl st = List.map (fun x -> sub cl st x used) in
+
+  match p with
   | Var x -> sub cl st (lookup st x) used
-  | Fifo plst -> Fifo (sub_plst cl st plst)
+  | Fifo set -> Fifo (sub_set cl set used)
+  | EarliestDeadline set -> EarliestDeadline (sub_set cl set used)
+  | ShortestJobNext set -> ShortestJobNext (sub_set cl set used)
+  | ShortestRemaining set -> ShortestRemaining (sub_set cl set used)
   | RoundRobin plst -> RoundRobin (sub_plst cl st plst)
   | Strict plst -> Strict (sub_plst cl st plst)
-  | WeightedFair wplst -> WeightedFair (sub_weighted_plst cl st wplst)
+  | WeightedFair (plst, wts) -> WeightedFair (sub_plst cl st plst, wts)
   | _ -> failwith "ERROR: unsupported policy"
 
 (* Look up any variables and substitute them in. *)
 let of_program (cl, alst, ret) : t = sub cl alst ret (ref [])
+
+let rec set_to_string p =
+  let sprintf = Printf.sprintf in
+  match p with
+  | Class c -> c
+  | Union lst ->
+      sprintf "union[%s]" (lst |> List.map set_to_string |> String.concat ",")
 
 let rec to_string p =
   let sprintf = Printf.sprintf in
   let join lst =
     sprintf "[%s]" (lst |> List.map to_string |> String.concat ", ")
   in
-  let join_weighted lst =
-    sprintf "[%s]"
-      (lst
-      |> List.map (fun (x, y) -> sprintf "(%s, %.2f)" (to_string x) y)
-      |> String.concat ", ")
+  let join_ints lst =
+    sprintf "[%s]" (lst |> List.map string_of_int |> String.concat ", ")
   in
 
   match p with
-  | Class c -> c
-  | Fifo lst -> sprintf "fifo%s" (join lst)
+  | Fifo set -> sprintf "fifo%s" (set_to_string set)
+  | EarliestDeadline set -> sprintf "edf%s" (set_to_string set)
+  | ShortestJobNext set -> sprintf "sjn%s" (set_to_string set)
+  | ShortestRemaining set -> sprintf "fifo%s" (set_to_string set)
   | RoundRobin lst -> sprintf "rr%s" (join lst)
   | Strict lst -> sprintf "strict%s" (join lst)
-  | WeightedFair lst -> sprintf "wfq%s" (join_weighted lst)
+  | WeightedFair (lst, wts) -> sprintf "wfq%s %s" (join lst) (join_ints wts)

--- a/rio/frontend/policy.ml
+++ b/rio/frontend/policy.ml
@@ -51,11 +51,11 @@ let rec sub cl st (p : Ast.policy) used =
   | Fifo p -> Fifo (sub_set cl st p used)
   | RoundRobin plst -> extract_subpol (RoundRobin (sub_plst cl st plst))
   | Strict plst -> extract_subpol (Strict (sub_plst cl st plst))
-  | WeightedFair (plst, wts) ->
+  | WeightedFair wplst ->
       extract_subpol
         (WeightedFair
            (sub_weighted_plst cl st
-              (List.combine plst (List.map float_of_int wts))))
+              (List.map (fun (x, y) -> (x, float_of_int y)) wplst)))
   | _ -> failwith "ERROR: unsupported policy"
 
 (* Look up any variables and substitute them in. *)

--- a/rio/frontend/policy.ml
+++ b/rio/frontend/policy.ml
@@ -1,16 +1,10 @@
 (* Changes to this type must also be reflected in `Ast.policy` in ast.ml *)
-type set =
-  | Class of Ast.clss
-  | Union of set list
-
 type t =
-  | Fifo of set
-  | EarliestDeadline of set
-  | ShortestJobNext of set
-  | ShortestRemaining of set
+  | Class of Ast.clss
+  | Fifo of t list
   | RoundRobin of t list
   | Strict of t list
-  | WeightedFair of t list * int list
+  | WeightedFair of (t * float) list
 
 exception UnboundVariable of Ast.var
 exception UndeclaredClass of Ast.clss
@@ -21,56 +15,44 @@ let lookup s x =
   | Some v -> v
   | None -> raise (UnboundVariable x)
 
-let rec sub_set cl (p : Ast.set) used : set =
-  let sub_slst = List.map (fun x -> sub_set cl x used) in
+let rec sub cl st (p : Ast.policy) used =
+  let sub_plst cl st = List.map (fun x -> sub cl st x used) in
+  let sub_weighted_plst cl st =
+    List.map (fun (x, i) -> (sub cl st x used, i))
+  in
 
   match p with
   | Class c ->
       if List.mem c !used then raise (DuplicateClass c)
       else if List.mem c cl then (
         used := c :: !used;
-        (Class c : set))
+        (Class c : t))
       else raise (UndeclaredClass c)
-  | Union clst -> Union (sub_slst clst)
-
-let rec sub cl st (p : Ast.policy) used =
-  let sub_plst cl st = List.map (fun x -> sub cl st x used) in
-
-  match p with
   | Var x -> sub cl st (lookup st x) used
-  | Fifo set -> Fifo (sub_set cl set used)
-  | EarliestDeadline set -> EarliestDeadline (sub_set cl set used)
-  | ShortestJobNext set -> ShortestJobNext (sub_set cl set used)
-  | ShortestRemaining set -> ShortestRemaining (sub_set cl set used)
+  | Fifo plst -> Fifo (sub_plst cl st plst)
   | RoundRobin plst -> RoundRobin (sub_plst cl st plst)
   | Strict plst -> Strict (sub_plst cl st plst)
-  | WeightedFair (plst, wts) -> WeightedFair (sub_plst cl st plst, wts)
+  | WeightedFair wplst -> WeightedFair (sub_weighted_plst cl st wplst)
   | _ -> failwith "ERROR: unsupported policy"
 
 (* Look up any variables and substitute them in. *)
 let of_program (cl, alst, ret) : t = sub cl alst ret (ref [])
-
-let rec set_to_string p =
-  let sprintf = Printf.sprintf in
-  match p with
-  | Class c -> c
-  | Union lst ->
-      sprintf "union[%s]" (lst |> List.map set_to_string |> String.concat ",")
 
 let rec to_string p =
   let sprintf = Printf.sprintf in
   let join lst =
     sprintf "[%s]" (lst |> List.map to_string |> String.concat ", ")
   in
-  let join_ints lst =
-    sprintf "[%s]" (lst |> List.map string_of_int |> String.concat ", ")
+  let join_weighted lst =
+    sprintf "[%s]"
+      (lst
+      |> List.map (fun (x, y) -> sprintf "(%s, %.2f)" (to_string x) y)
+      |> String.concat ", ")
   in
 
   match p with
-  | Fifo set -> sprintf "fifo%s" (set_to_string set)
-  | EarliestDeadline set -> sprintf "edf%s" (set_to_string set)
-  | ShortestJobNext set -> sprintf "sjn%s" (set_to_string set)
-  | ShortestRemaining set -> sprintf "fifo%s" (set_to_string set)
+  | Class c -> c
+  | Fifo lst -> sprintf "fifo%s" (join lst)
   | RoundRobin lst -> sprintf "rr%s" (join lst)
   | Strict lst -> sprintf "strict%s" (join lst)
-  | WeightedFair (lst, wts) -> sprintf "wfq%s %s" (join lst) (join_ints wts)
+  | WeightedFair lst -> sprintf "wfq%s" (join_weighted lst)

--- a/rio/frontend/policy.ml
+++ b/rio/frontend/policy.ml
@@ -15,6 +15,18 @@ let lookup s x =
   | Some v -> v
   | None -> raise (UnboundVariable x)
 
+let rec sub_set cl st (p : Ast.set) used =
+  match p with
+  | Class c ->
+      if List.mem c !used then raise (DuplicateClass c)
+      else if List.mem c cl then (
+        used := c :: !used;
+        [ Class c ])
+      else raise (UndeclaredClass c)
+  | Union slst ->
+      let subbed = List.map (fun x -> sub_set cl st x used) slst in
+      List.flatten subbed
+
 let rec sub cl st (p : Ast.policy) used =
   let sub_plst cl st = List.map (fun x -> sub cl st x used) in
   let sub_weighted_plst cl st =
@@ -22,17 +34,14 @@ let rec sub cl st (p : Ast.policy) used =
   in
 
   match p with
-  | Class c ->
-      if List.mem c !used then raise (DuplicateClass c)
-      else if List.mem c cl then (
-        used := c :: !used;
-        (Class c : t))
-      else raise (UndeclaredClass c)
   | Var x -> sub cl st (lookup st x) used
-  | Fifo plst -> Fifo (sub_plst cl st plst)
+  | Fifo p -> Fifo (sub_set cl st p used)
   | RoundRobin plst -> RoundRobin (sub_plst cl st plst)
   | Strict plst -> Strict (sub_plst cl st plst)
-  | WeightedFair wplst -> WeightedFair (sub_weighted_plst cl st wplst)
+  | WeightedFair (plst, wts) ->
+      WeightedFair
+        (sub_weighted_plst cl st
+           (List.combine plst (List.map float_of_int wts)))
   | _ -> failwith "ERROR: unsupported policy"
 
 (* Look up any variables and substitute them in. *)

--- a/rio/frontend/policy.mli
+++ b/rio/frontend/policy.mli
@@ -1,10 +1,17 @@
 (* Changes to this type must also be reflected in `Ast.policy` in ast.ml *)
-type t =
+
+type set =
   | Class of Ast.clss
-  | Fifo of t list
+  | Union of set list
+
+type t =
+  | Fifo of set
+  | EarliestDeadline of set
+  | ShortestJobNext of set
+  | ShortestRemaining of set
   | RoundRobin of t list
   | Strict of t list
-  | WeightedFair of (t * float) list
+  | WeightedFair of t list * int list
 
 exception UnboundVariable of Ast.var
 exception UndeclaredClass of Ast.clss

--- a/rio/frontend/policy.mli
+++ b/rio/frontend/policy.mli
@@ -1,17 +1,10 @@
 (* Changes to this type must also be reflected in `Ast.policy` in ast.ml *)
-
-type set =
-  | Class of Ast.clss
-  | Union of set list
-
 type t =
-  | Fifo of set
-  | EarliestDeadline of set
-  | ShortestJobNext of set
-  | ShortestRemaining of set
+  | Class of Ast.clss
+  | Fifo of t list
   | RoundRobin of t list
   | Strict of t list
-  | WeightedFair of t list * int list
+  | WeightedFair of (t * float) list
 
 exception UnboundVariable of Ast.var
 exception UndeclaredClass of Ast.clss

--- a/rio/simulator/state.mli
+++ b/rio/simulator/state.mli
@@ -4,7 +4,7 @@ exception UnboundKey of string
 
 val empty : t
 val rebind : string -> float -> t -> t
-val rebind_all : (string * float) list -> t -> t
+val rebind_all : (string * 'a) list -> t -> t
 val is_defined : string -> t -> bool
 val lookup : string -> t -> float
 val lookup_opt : string -> t -> float option

--- a/rio/simulator/state.mli
+++ b/rio/simulator/state.mli
@@ -4,7 +4,7 @@ exception UnboundKey of string
 
 val empty : t
 val rebind : string -> float -> t -> t
-val rebind_all : (string * 'a) list -> t -> t
+val rebind_all : (string * float) list -> t -> t
 val is_defined : string -> t -> bool
 val lookup : string -> t -> float
 val lookup_opt : string -> t -> float option

--- a/rio/simulator/topo.ml
+++ b/rio/simulator/topo.ml
@@ -14,10 +14,9 @@ let rec addr_to_string = function
 
 let rec of_policy (p : Frontend.Policy.t) =
   match p with
-  | Fifo _ | EarliestDeadline _ | ShortestJobNext _ | ShortestRemaining _ ->
-      Node [ Star ]
-  | RoundRobin plst | Strict plst -> Node (List.map of_policy plst)
-  | WeightedFair (wplst, _) -> Node (List.map of_policy wplst)
+  | Class _ -> Star
+  | Fifo plst | RoundRobin plst | Strict plst -> Node (List.map of_policy plst)
+  | WeightedFair wplst -> Node (List.map (fun (p, _) -> of_policy p) wplst)
 
 let rec height = function
   | Star -> 1

--- a/rio/simulator/topo.ml
+++ b/rio/simulator/topo.ml
@@ -14,9 +14,10 @@ let rec addr_to_string = function
 
 let rec of_policy (p : Frontend.Policy.t) =
   match p with
-  | Class _ -> Star
-  | Fifo plst | RoundRobin plst | Strict plst -> Node (List.map of_policy plst)
-  | WeightedFair wplst -> Node (List.map (fun (p, _) -> of_policy p) wplst)
+  | Fifo _ | EarliestDeadline _ | ShortestJobNext _ | ShortestRemaining _ ->
+      Node [ Star ]
+  | RoundRobin plst | Strict plst -> Node (List.map of_policy plst)
+  | WeightedFair (wplst, _) -> Node (List.map of_policy wplst)
 
 let rec height = function
   | Star -> 1

--- a/rio/tests/parsing.ml
+++ b/rio/tests/parsing.ml
@@ -70,7 +70,7 @@ let error_tests =
       "progs/incorrect/duplicate_samepol.sched" (Policy.DuplicateClass "A");
     make_error_test "fifo for multiple classes without union"
       "progs/incorrect/set_multiple.sched"
-      (Parser.ParserError "Syntax error at line 3, character 17");
+      (Parser.ParserError "Syntax error at line 4, character 17");
     make_error_test "rr for classes without fifo'ing first"
       "progs/incorrect/set_hierarchical.sched"
       (Parser.ParserError "Syntax error at line 3, character 14");

--- a/rio/tests/parsing.ml
+++ b/rio/tests/parsing.ml
@@ -11,30 +11,35 @@ let make_error_test name filename exn =
 let wc_tests =
   [
     make_test "single class policy" "progs/work_conserving/drop_a_class.sched"
-      "A";
+      "fifo[A]";
     make_test "fifo 1 class" "progs/work_conserving/fifo_1_class_sugar.sched"
-      "A";
-    make_test "fifo 1 class" "progs/work_conserving/fifo_1_class.sched" "A";
+      "fifo[A]";
+    make_test "fifo 1 class" "progs/work_conserving/fifo_1_class.sched"
+      "fifo[A]";
     make_test "fifo of 3" "progs/work_conserving/fifo_n_classes.sched"
       "fifo[A, B, C]";
-    make_test "rr of 1" "progs/work_conserving/rr_1_class.sched" "rr[A]";
-    make_test "rr of 2" "progs/work_conserving/rr_2_classes.sched" "rr[A, B]";
+    make_test "rr of 1" "progs/work_conserving/rr_1_class.sched" "rr[fifo[A]]";
+    make_test "rr of 2" "progs/work_conserving/rr_2_classes.sched"
+      "rr[fifo[A, B]]";
     make_test "multiple assignments"
       "progs/work_conserving/rr_hier_merge_sugar.sched"
-      "rr[fifo[BX, BY], rr[RP, RT]]";
+      "rr[fifo[BX, BY], rr[fifo[RP], fifo[RT]]]";
     make_test "2 assignments w/ substitutions"
-      "progs/work_conserving/rr_hier.sched" "rr[B, rr[RP, RT]]";
+      "progs/work_conserving/rr_hier.sched"
+      "rr[fifo[B], rr[fifo[RP], fifo[RT]]]";
     make_test "3 classes with substitutions"
       "progs/work_conserving/rr_n_class_hier.sched"
-      "rr[A, B, rr[rr[CU, CV], rr[CW, CX]]]";
-    make_test "rr of 3" "progs/work_conserving/rr_n_classes.sched" "rr[A, B, C]";
+      "rr[fifo[A], fifo[B], rr[rr[fifo[CU], fifo[CV]], rr[fifo[CW], fifo[CX]]]]";
+    make_test "rr of 3" "progs/work_conserving/rr_n_classes.sched"
+      "rr[fifo[A], fifo[B], fifo[C]]";
     make_test "rr and strict substitutions"
       "progs/work_conserving/rr_strict_n_classes_hier.sched"
-      "strict[A, B, rr[rr[CU, CV], strict[CW, CX]]]";
+      "strict[fifo[A], fifo[B], rr[rr[fifo[CU], fifo[CV]], strict[fifo[CW], \
+       fifo[CX]]]]";
     make_test "strict of 3" "progs/work_conserving/strict_n_classes.sched"
-      "strict[C, B, A]";
+      "strict[fifo[C], fifo[B], fifo[A]]";
     make_test "wfq of 3" "progs/work_conserving/wfq_n_classes.sched"
-      "wfq[(A, 0.10), (B, 0.20), (C, 0.30)]";
+      "wfq[(fifo[A], 1.00), (fifo[B], 2.00), (fifo[C], 3.00)]";
   ]
 
 let _nwc_tests =

--- a/rio/tests/parsing.ml
+++ b/rio/tests/parsing.ml
@@ -18,28 +18,25 @@ let wc_tests =
       "fifo[A]";
     make_test "fifo of 3" "progs/work_conserving/fifo_n_classes.sched"
       "fifo[A, B, C]";
-    make_test "rr of 1" "progs/work_conserving/rr_1_class.sched" "rr[fifo[A]]";
+    make_test "rr of 1" "progs/work_conserving/rr_1_class.sched" "rr[A]";
     make_test "rr of 2" "progs/work_conserving/rr_2_classes.sched"
       "rr[fifo[A, B]]";
     make_test "multiple assignments"
       "progs/work_conserving/rr_hier_merge_sugar.sched"
-      "rr[fifo[BX, BY], rr[fifo[RP], fifo[RT]]]";
+      "rr[fifo[BX, BY], rr[RP, RT]]";
     make_test "2 assignments w/ substitutions"
-      "progs/work_conserving/rr_hier.sched"
-      "rr[fifo[B], rr[fifo[RP], fifo[RT]]]";
+      "progs/work_conserving/rr_hier.sched" "rr[B, rr[RP, RT]]";
     make_test "3 classes with substitutions"
       "progs/work_conserving/rr_n_class_hier.sched"
-      "rr[fifo[A], fifo[B], rr[rr[fifo[CU], fifo[CV]], rr[fifo[CW], fifo[CX]]]]";
-    make_test "rr of 3" "progs/work_conserving/rr_n_classes.sched"
-      "rr[fifo[A], fifo[B], fifo[C]]";
+      "rr[A, B, rr[rr[CU, CV], rr[CW, CX]]]";
+    make_test "rr of 3" "progs/work_conserving/rr_n_classes.sched" "rr[A, B, C]";
     make_test "rr and strict substitutions"
       "progs/work_conserving/rr_strict_n_classes_hier.sched"
-      "strict[fifo[A], fifo[B], rr[rr[fifo[CU], fifo[CV]], strict[fifo[CW], \
-       fifo[CX]]]]";
+      "strict[A, B, rr[rr[CU, CV], strict[CW, CX]]]";
     make_test "strict of 3" "progs/work_conserving/strict_n_classes.sched"
-      "strict[fifo[C], fifo[B], fifo[A]]";
+      "strict[C, B, A]";
     make_test "wfq of 3" "progs/work_conserving/wfq_n_classes.sched"
-      "wfq[(fifo[A], 1.00), (fifo[B], 2.00), (fifo[C], 3.00)]";
+      "wfq[(A, 1.00), (B, 2.00), (C, 3.00)]";
   ]
 
 let _nwc_tests =

--- a/rio/tests/parsing.ml
+++ b/rio/tests/parsing.ml
@@ -71,6 +71,12 @@ let error_tests =
       "progs/incorrect/duplicate_classes.sched" (Policy.DuplicateClass "B");
     make_error_test "class used twice in one fifo"
       "progs/incorrect/duplicate_samepol.sched" (Policy.DuplicateClass "A");
+    make_error_test "fifo for multiple classes without union"
+      "progs/incorrect/set_multiple.sched"
+      (Parser.ParserError "Syntax error at line 3, character 17");
+    make_error_test "rr for classes without fifo'ing first"
+      "progs/incorrect/set_hierarchical.sched"
+      (Parser.ParserError "Syntax error at line 3, character 14");
   ]
 
 let suite = "parsing tests" >::: wc_tests @ error_tests (* @ nwc_tests *)


### PR DESCRIPTION
### Background

#55 discusses a need for a modified AST that distinguishes between **set-to-stream** and **stream-to-stream** policies, and furthermore distinguishes between **sets** and **streams**. Within that, we discuss the need for a `Union` operator, which effectively 'merges several classes into one'. This is critical in the construction of Set-to-Stream transformers, to allow such polices to arbitrate independent of queue distinctions.

### Overview

My work on the type system in #63 allowed us to realize that we could turn typechecking into essentially an abstraction, and have our `set` and `stream` types inferred at parsing-time itself – that is to say, with a tweak to the AST and extending it to the parser as well. That's the first part part of the PR, which entails adding in the `Union` constructor to the AST, and partitioning it into the `set` and `stream` types.

### Caveat And Explanation

@polybeandip and I discussed how far we thought this change should extend. On one hand, modifying `Ast.t` contractually requires us to modify `Policy.t`. An alternative, though, is to simply establish a correspondence `Ast.t -> Policy.t`. For simplicity and to preserve the work done in `control`, we have kept `Policy.t` in its original form, and adapted that correspondence.

In turn, this required modifying almost all of our programs such that they would be syntactically correct w.rt. the new AST structure and parsing mechanisms. In addition, a few extra 'reversions' to allow for parsed programs to be correctly evaluated in `control`.