### PR TITLE
Allow Rio to parse Variables/Classes with multiple cases

### DIFF
--- a/progs/work_conserving/fifo_camel_vars.sched
+++ b/progs/work_conserving/fifo_camel_vars.sched
@@ -1,0 +1,7 @@
+classes CLASS_A, CLASS_B, CLASS_C, CLASS_D;
+
+firstPolicy = fifo[union[CLASS_A, CLASS_B]];
+
+secondPolicy = fifo[union[CLASS_C, CLASS_D]];
+
+return rr[firstPolicy, secondPolicy];

--- a/progs/work_conserving/fifo_noncap_classes.sched
+++ b/progs/work_conserving/fifo_noncap_classes.sched
@@ -1,0 +1,5 @@
+classes CLASS_A, CLASS_B, CLASS_C;
+
+firstPolicy = fifo[union[CLASS_A, CLASS_B, CLASS_C]];
+
+return firstPolicy

--- a/progs/work_conserving/fifo_noncap_classes.sched
+++ b/progs/work_conserving/fifo_noncap_classes.sched
@@ -1,5 +1,5 @@
 classes CLASS_A, CLASS_B, CLASS_C;
 
-firstPolicy = fifo[union[CLASS_A, CLASS_B, CLASS_C]];
+policy = fifo[union[CLASS_A, CLASS_B, CLASS_C]];
 
-return firstPolicy
+return policy

--- a/rio/frontend/lexer.mll
+++ b/rio/frontend/lexer.mll
@@ -5,8 +5,8 @@
 let whitespace = [' ' '\t']+
 let int = '-'? ['0'-'9']+
 let float = '-'? (['0'-'9']* '.')? ['0'-'9']+
-let id = ['a'-'z'] ['a'-'z' '0'-'9' '_']*
-let bigid = ['A'-'Z']*
+let varid = ['a'-'z'] ['a'-'z' 'A'-'Z' '0'-'9' '_']*
+let classid = ['A'-'Z']['A'-'Z' 'a'-'z' '0'-'9' '_']*
 let comment = ['/' '/'] ['\x00' - '\x09']* ['\x0b' - '\x80']*
 
 rule token = parse
@@ -38,8 +38,8 @@ rule token = parse
 | "tokenbucket"         { TOKEN }
 | "stopandgo"           { STOPGO }
 | ";"                   { SEMICOLON }
-| id as v               { VAR(v) }
-| bigid as i            { CLSS(i) }
+| varid as v            { VAR(v) }
+| classid as i          { CLSS(i) }
 | int                   { INT (int_of_string (Lexing.lexeme lexbuf)) }
 | eof                   { EOF }
 

--- a/rio/tests/parsing.ml
+++ b/rio/tests/parsing.ml
@@ -37,9 +37,12 @@ let wc_tests =
       "strict[C, B, A]";
     make_test "wfq of 3" "progs/work_conserving/wfq_n_classes.sched"
       "wfq[(A, 1.00), (B, 2.00), (C, 3.00)]";
-    make_test "fifo with non-capitalized classes"
+    make_test "fifo with class names not including capital letters"
       "progs/work_conserving/fifo_noncap_classes.sched"
       "fifo[CLASS_A, CLASS_B, CLASS_C]";
+    make_test "rr and fifo with camelCase variables"
+      "progs/work_conserving/fifo_camel_vars.sched"
+      "rr[fifo[CLASS_A, CLASS_B], fifo[CLASS_C, CLASS_D]]";
   ]
 
 let _nwc_tests =

--- a/rio/tests/parsing.ml
+++ b/rio/tests/parsing.ml
@@ -37,6 +37,9 @@ let wc_tests =
       "strict[C, B, A]";
     make_test "wfq of 3" "progs/work_conserving/wfq_n_classes.sched"
       "wfq[(A, 1.00), (B, 2.00), (C, 3.00)]";
+    make_test "fifo with non-capitalized classes"
+      "progs/work_conserving/fifo_noncap_classes.sched"
+      "fifo[CLASS_A, CLASS_B, CLASS_C]";
   ]
 
 let _nwc_tests =


### PR DESCRIPTION
This PR resolves #77 by extending the regex formats accepted for classes and variables in our lexer.

Presently, Rio only accepts classes that consist of only capital letters that is to say, `CLASS_A` or `FirstClass` are both illegal, while `FIRSTCLASS` is fine. However, we feel that it may be pragmatic to allow class declarations similar to how they might be done in Java, or how modules may be constructed on OCaml. 

Equivalently, our language extends this for variables as well. While something like `firstPolicy` wouldn't have been allowed earlier, we extend it to allow capital letters as well.

**Testing**. Two example programs based on the failing cases from earlier. They should achieve full coverage of what we need, but more may be desirable.

**Caveat**. I feel however that there should still be _some_ distinction between variables and classes. @polybeandip points out an example where a variable like `Pol` should be allowed; I disagree with this. I think **variables should begin with a lowercase letter**, but can subsequently contain whichever characters one would want. Likewise, I think classes should begin with an uppercase letter, but can subsequently have other characters. This seems in line with equivalent 'classes' and 'variables' in other languages.

Let me know if this is worth changing though!