### PR TITLE
Try to improve caching in workflow builds

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -19,10 +19,9 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set-up OCaml
-        uses: ocaml/setup-ocaml@v4
+        uses: ocaml/setup-ocaml@v3
         with:
           ocaml-compiler: 5
-          cache: true
           dune-cache: true
 
       - name: Install dependencies

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -2,11 +2,11 @@ name: Format
 
 on:
   push:
+    branches: [main]
   pull_request:
     branches: [main]
 
-# Ensures that only the latest commit of a PR can execute the actions.
-# Useful for cancelling job when a sequence of commits are quickly added.
+# Only run the latest commit for a PR
 concurrency:
   group: ${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
@@ -17,13 +17,18 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
       - name: Set-up OCaml
         uses: ocaml/setup-ocaml@v3
         with:
           ocaml-compiler: 5
-      - name: Install ocamlformat
+          cache: true
+          dune-cache: true
+
+      - name: Install dependencies
         working-directory: rio
-        run: opam install ocamlformat.0.28.1
+        run: opam install . --deps-only --with-test
+
       - name: Check format
         working-directory: rio
         run: opam exec -- dune build @fmt

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set-up OCaml
-        uses: ocaml/setup-ocaml@v3
+        uses: ocaml/setup-ocaml@v4
         with:
           ocaml-compiler: 5
           cache: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,8 +5,6 @@ on:
   pull_request:
     branches: [main]
 
-# Ensures that only the latest commit of a PR can execute the actions.
-# Useful for cancelling job when a sequence of commits are quickly added.
 concurrency:
   group: ${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
@@ -17,17 +15,22 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
       - name: Set-up OCaml
         uses: ocaml/setup-ocaml@v3
         with:
           ocaml-compiler: 5
+          cache: true
+          dune-cache: true
+
       - name: Install dependencies
         working-directory: rio
-        run: | 
-          opam install . --deps-only
-      - name: Rio tests
-        working-directory: rio
-        run: |
-          opam exec -- dune build
-          opam exec -- dune test
+        run: opam install . --deps-only --with-test
 
+      - name: Build
+        working-directory: rio
+        run: opam exec -- dune build
+
+      - name: Run tests
+        working-directory: rio
+        run: opam exec -- dune test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set-up OCaml
-        uses: ocaml/setup-ocaml@v3
+        uses: ocaml/setup-ocaml@v4
         with:
           ocaml-compiler: 5
           cache: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,10 +17,9 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set-up OCaml
-        uses: ocaml/setup-ocaml@v4
+        uses: ocaml/setup-ocaml@v3
         with:
           ocaml-compiler: 5
-          cache: true
           dune-cache: true
 
       - name: Install dependencies

--- a/rio/rio.opam
+++ b/rio/rio.opam
@@ -20,6 +20,7 @@ depends: [
   "mmap"
   "csv"
   "yojson"
+  "ocamlformat" {= "0.28.1"}
   "odoc" {with-doc}
 ]
 build: [


### PR DESCRIPTION
Two things:
- I have turned on dune caching to see if it speeds up workflow builds
- I have added ocamlformat, including its version, to the list of dependencies, and have got the workflow to install the dependencies as written. This means that there isn't as much of a chance of a version mismatch between the user's local version and the version that the workflow actually installs.