### PR TITLE
Generate fewer assoc-deassoc and map-unmap pairs

### DIFF
--- a/rio/ir/ir.ml
+++ b/rio/ir/ir.ml
@@ -228,15 +228,27 @@ let replace_at ~prev ~chain ~removed ~arm_depth ~arm ~rewrite_decorated =
   in
   let removed_v = Decorated.root_vpifo removed in
   let removed_classes = Decorated.subtree_classes removed in
+  let new_classes = arm_frag.classes in
+  (* Classes shared between the removed subtree and the new arm keep their
+     existing routing on every ancestor: the chain steps are preserved (the
+     bottom-of-chain step survives because [Designate] reuses the parent's
+     existing step, and ancestors above are untouched). So the only edits
+     needed are on the symmetric difference. *)
+  let only_removed =
+    List.filter (fun c -> not (List.mem c new_classes)) removed_classes
+  in
+  let only_added =
+    List.filter (fun c -> not (List.mem c removed_classes)) new_classes
+  in
   let prog =
     List.concat
       [
         Frag.to_program arm_frag;
         [ Designate (removed_v, arm_frag.root_v) ];
-        chain_emit (fun v s c -> Unmap (v, c, s)) chain removed_classes;
-        chain_emit (fun v _ c -> Deassoc (v, c)) chain removed_classes;
-        chain_emit (fun v _ c -> Assoc (v, c)) chain arm_frag.classes;
-        chain_emit (fun v s c -> Map (v, c, s)) chain arm_frag.classes;
+        chain_emit (fun v s c -> Unmap (v, c, s)) chain only_removed;
+        chain_emit (fun v _ c -> Deassoc (v, c)) chain only_removed;
+        chain_emit (fun v _ c -> Assoc (v, c)) chain only_added;
+        chain_emit (fun v s c -> Map (v, c, s)) chain only_added;
         gc_subtree removed;
       ]
   in

--- a/rio/tests/ir/test_patch.ml
+++ b/rio/tests/ir/test_patch.ml
@@ -242,10 +242,9 @@ let rr_ab_to_rr_def_expected : program =
    sp[A,B] (vpifos 100/101/102, steps 1000/1001); next = rr[A,B] —
    same children, different root policy, so Compare can't ride the
    existing slots. Same handler as the [VeryDifferent []] case above:
-   builds the new tree off fresh ids, [Designate]s, drains, rewrites
-   the fake root's classifier. The class sets coincide here so
-   {Unmap,Deassoc,Assoc,Map} on the fake root cancel semantically, but
-   the instructions are still emitted. *)
+   builds the new tree off fresh ids, [Designate]s, drains. The class
+   sets coincide here so the fake root's existing routing is preserved
+   and no {Unmap,Deassoc,Assoc,Map} land on it. *)
 let strict_ab_to_rr_ab_expected : program =
   [
     Spawn (103, 0);
@@ -261,14 +260,6 @@ let strict_ab_to_rr_ab_expected : program =
     Map (103, "B", 1003);
     Change_pol (103, RR, 2);
     Designate (100, 103);
-    Unmap (99, "A", 999);
-    Unmap (99, "B", 999);
-    Deassoc (99, "A");
-    Deassoc (99, "B");
-    Assoc (99, "A");
-    Assoc (99, "B");
-    Map (99, "A", 999);
-    Map (99, "B", 999);
     GC 100;
     GC 101;
     GC 102;


### PR DESCRIPTION
We have known for a minute that our IL-gen sometimes emits patches that contain `instr`s that cancel each other out. This PR reduces instances of that by emitting `map`, `unmaps`, `assoc` and `deassoc` instructions a little more conservatively. Essentially we take set differences. This is not a post-emission pass; it's just a slightly cleverer emission in the first place. Below you can see a simple example that goes from 24 instructions to 16.