### PR TITLE
Deal with WFQ arm addition/replacement via two new variants in `compare.ml`

### DIFF
--- a/rio/bin/compare.ml
+++ b/rio/bin/compare.ml
@@ -13,6 +13,10 @@ type t =
   | WeightChanged of weight_change
   | OneArmReplaced of arm_diff
     (* Wholesale replacement of the subtree at [path] with [arm]. If [path] is nil, that means we're not (yet) clever enough to specify the change and the arm being replaced is the whole tree. *)
+  | OneArmReplacedWFQ of arm_diff_w
+    (* WFQ-specific arm replacement: a single WFQ slot's arm and weight
+       both changed. Bundles the new arm and the new weight together so
+       it doesn't decompose into [OneArmReplaced] + [WeightChanged]. *)
   | SuperPol of path (* [path] points to [prev] inside [next]. *)
   | SubPol of path (* [path] points to [next] inside [prev]. *)
 
@@ -87,6 +91,7 @@ let prepend_path i diff =
   | OneArmRemoved ad -> OneArmRemoved (prepend_arm ad)
   | WeightChanged wc -> WeightChanged (prepend_wc wc)
   | OneArmReplaced ad -> OneArmReplaced (prepend_arm ad)
+  | OneArmReplacedWFQ ad -> OneArmReplacedWFQ (prepend_arm_w ad)
   | SuperPol p -> SuperPol (i :: p)
   | SubPol p -> SubPol (i :: p)
 
@@ -181,20 +186,39 @@ and compare_wfq_children ~next:p2 ps1 (ws1 : float list) ps2 (ws2 : float list)
           (* Detected more than one point of difference. We can't handle that yet. *)
           give_up
     end
-  | false, false -> begin
-      (* Both lists changed. A single edit could be either an arm
-         removal or a WFQ-style arm addition. In each case the same
-         slot must show up as the lone difference in both the policy
-         list and the weight list, confirming one consistent edit. *)
-      match (insertions ps1 ps2, insertions ws1 ws2) with
-      | Some [ (i, arm) ], Some [ (j, weight) ] when i = j ->
-          OneArmAddedWFQ { path = [ i ]; arm; weight }
-      | _ -> (
-          match (insertions ps2 ps1, insertions ws2 ws1) with
-          | Some [ (i, arm) ], Some [ (j, _) ] when i = j ->
-              OneArmRemoved { path = [ i ]; arm }
-          | _ -> give_up)
-    end
+  | false, false ->
+      (* Both lists changed. We can describe a single edit in three
+         shapes: an arm-add (one new slot in [next]), an arm-remove (one
+         dropped slot), or an arm-replace at one slot whose arm and
+         weight both changed. In each case the same slot index must
+         show up as the lone difference in both the policy list and
+         the weight list, confirming one consistent edit. *)
+      if List.length ps1 = List.length ps2 then begin
+        (* Same length: only a WFQ arm-replace can land here. The slot
+           must show as a single in-place difference in both [ps] and
+           [ws], and that slot's arm-vs-arm diff must itself be a
+           leaf-level replacement (otherwise we'd be folding a deep
+           arm change with a weight change into one variant, which
+           [Ir.patch] can't currently express). *)
+        match (changes ps1 ps2, changes ws1 ws2) with
+        | [ (i, _) ], [ (j, weight) ] when i = j -> begin
+            match analyze (List.nth ps1 i) (List.nth ps2 i) with
+            | OneArmReplaced { path = []; arm } ->
+                OneArmReplacedWFQ { path = [ i ]; arm; weight }
+            | _ -> give_up
+          end
+        | _ -> give_up
+      end
+      else begin
+        match (insertions ps1 ps2, insertions ws1 ws2) with
+        | Some [ (i, arm) ], Some [ (j, weight) ] when i = j ->
+            OneArmAddedWFQ { path = [ i ]; arm; weight }
+        | _ -> (
+            match (insertions ps2 ps1, insertions ws2 ws1) with
+            | Some [ (i, arm) ], Some [ (j, _) ] when i = j ->
+                OneArmRemoved { path = [ i ]; arm }
+            | _ -> give_up)
+      end
 
 and analyze p1 p2 =
   if p1 = p2 then Same
@@ -251,5 +275,7 @@ let to_string = function
       Printf.sprintf "WeightChanged: %s" (string_of_weight_change wc)
   | OneArmReplaced ad ->
       Printf.sprintf "OneArmReplaced: %s" (string_of_arm_diff ad)
+  | OneArmReplacedWFQ ad ->
+      Printf.sprintf "OneArmReplacedWFQ: %s" (string_of_arm_diff_w ad)
   | SuperPol p -> Printf.sprintf "SuperPol at %s" (path_to_string p)
   | SubPol p -> Printf.sprintf "SubPol at %s" (path_to_string p)

--- a/rio/bin/compare.ml
+++ b/rio/bin/compare.ml
@@ -6,6 +6,9 @@ type path = int list
 type t =
   | Same
   | OneArmAdded of arm_diff
+  | OneArmAddedWFQ of arm_diff_w
+    (* WFQ-specific arm addition. Adding a slot to a WFQ parent always
+       carries a weight, so the new arm and its weight are a single edit. *)
   | OneArmRemoved of arm_diff
   | WeightChanged of weight_change
   | OneArmReplaced of arm_diff
@@ -15,10 +18,16 @@ type t =
 
 and arm_diff = {
   path : path;
-      (* Path from the root to the position of this arm. 
+      (* Path from the root to the position of this arm.
       For [OneArmAdded] this is a position in *next*; for
           [OneArmRemoved] it is a position in *prev*. *)
   arm : Frontend.Policy.t;
+}
+
+and arm_diff_w = {
+  path : path;
+  arm : Frontend.Policy.t;
+  weight : float;
 }
 
 and weight_change = {
@@ -69,10 +78,12 @@ let changes prev next =
    the recursion). *)
 let prepend_path i diff =
   let prepend_arm (ad : arm_diff) = { ad with path = i :: ad.path } in
+  let prepend_arm_w (ad : arm_diff_w) = { ad with path = i :: ad.path } in
   let prepend_wc (wc : weight_change) = { wc with path = i :: wc.path } in
   match diff with
   | Same -> Same
   | OneArmAdded ad -> OneArmAdded (prepend_arm ad)
+  | OneArmAddedWFQ ad -> OneArmAddedWFQ (prepend_arm_w ad)
   | OneArmRemoved ad -> OneArmRemoved (prepend_arm ad)
   | WeightChanged wc -> WeightChanged (prepend_wc wc)
   | OneArmReplaced ad -> OneArmReplaced (prepend_arm ad)
@@ -171,14 +182,18 @@ and compare_wfq_children ~next:p2 ps1 (ws1 : float list) ps2 (ws2 : float list)
           give_up
     end
   | false, false -> begin
-      (* Both lists changed. The only way this is a single edit is if it's an 
-         arm _removal_. We require the same drop position in both, as that
-         confirms we're looking at one consistent slot removal rather
-         than two coincidental edits. *)
-      match (insertions ps2 ps1, insertions ws2 ws1) with
-      | Some [ (i, arm) ], Some [ (j, _) ] when i = j ->
-          OneArmRemoved { path = [ i ]; arm }
-      | _ -> give_up
+      (* Both lists changed. A single edit could be either an arm
+         removal or a WFQ-style arm addition. In each case the same
+         slot must show up as the lone difference in both the policy
+         list and the weight list, confirming one consistent edit. *)
+      match (insertions ps1 ps2, insertions ws1 ws2) with
+      | Some [ (i, arm) ], Some [ (j, weight) ] when i = j ->
+          OneArmAddedWFQ { path = [ i ]; arm; weight }
+      | _ -> (
+          match (insertions ps2 ps1, insertions ws2 ws1) with
+          | Some [ (i, arm) ], Some [ (j, _) ] when i = j ->
+              OneArmRemoved { path = [ i ]; arm }
+          | _ -> give_up)
     end
 
 and analyze p1 p2 =
@@ -217,12 +232,19 @@ let string_of_arm_diff { path; arm } =
     (Frontend.Policy.to_string arm)
     (path_to_string path)
 
+let string_of_arm_diff_w { path; arm; weight } =
+  Printf.sprintf "%s (weight %g) at %s"
+    (Frontend.Policy.to_string arm)
+    weight (path_to_string path)
+
 let string_of_weight_change { path; new_weight } =
   Printf.sprintf "%s → %g" (path_to_string path) new_weight
 
 let to_string = function
   | Same -> "Same"
   | OneArmAdded ad -> Printf.sprintf "OneArmAdded: %s" (string_of_arm_diff ad)
+  | OneArmAddedWFQ ad ->
+      Printf.sprintf "OneArmAddedWFQ: %s" (string_of_arm_diff_w ad)
   | OneArmRemoved ad ->
       Printf.sprintf "OneArmRemoved: %s" (string_of_arm_diff ad)
   | WeightChanged wc ->

--- a/rio/bin/compare.ml
+++ b/rio/bin/compare.ml
@@ -76,6 +76,32 @@ let changes prev next =
   in
   loop 0 prev next []
 
+(* [Some (i, x)] iff [next] is [prev] with [x] inserted at index [i]; else
+   [None]. *)
+let single_insertion prev next =
+  match insertions prev next with
+  | Some [ (i, x) ] -> Some (i, x)
+  | _ -> None
+
+(* [Some (i, x)] iff [prev] and [next] have equal length and differ at exactly
+   one slot [i], where [next.(i) = x]. *)
+let single_change prev next =
+  match changes prev next with
+  | [ (i, x) ] -> Some (i, x)
+  | _ -> None
+
+(* Lockstep versions used by WFQ: a clean single edit must show up at the
+   same index in both the policy list and the weight list. *)
+let single_change_lockstep ps1 ps2 ws1 ws2 =
+  match (single_change ps1 ps2, single_change ws1 ws2) with
+  | Some (i, arm), Some (j, w) when i = j -> Some (i, arm, w)
+  | _ -> None
+
+let single_insertion_lockstep ps1 ps2 ws1 ws2 =
+  match (single_insertion ps1 ps2, single_insertion ws1 ws2) with
+  | Some (i, arm), Some (j, w) when i = j -> Some (i, arm, w)
+  | _ -> None
+
 (* Prepend [i] to every embedded [path] inside [diff]. Used by [compare]
    when descending: a child's diff comes back parent-relative, and we tack
    on the child's own index to make it grandparent-relative (and so on up
@@ -127,98 +153,82 @@ let rec is_sub_policy p1 p2 =
    divergence, mismatched insertions, etc.), we "give up" by emitting
    [OneArmReplaced { path = []; arm = p2 }]. *)
 and compare_children ~next:p2 ps1 ps2 =
-  (* Lengths differ by some number of insertions in one direction. We can
-     only describe the case of a single insertion: [insertions prev next]
-     returning exactly one diff means [next] is [prev] with one element
-     added at index [i]; package it with [constructor] (either [OneArmAdded] or 
-     [OneArmRemoved] depending on which direction we were checking). *)
   let give_up = OneArmReplaced { path = []; arm = p2 } in
-  let single_insert prev next constructor =
-    match insertions prev next with
-    | Some [ (i, arm) ] -> constructor { path = [ i ]; arm }
-    | _ -> give_up
-  in
-  let n = List.compare_lengths ps1 ps2 in
-  if n = 0 then begin
-    (* lists of same length *)
-    match changes ps1 ps2 with
-    | [] -> Same (* Shoudn't get here; this is [Same] at a higher level *)
-    | [ (i, _) ] ->
-        (* Exactly one slot differs. We recurse, since diff might be
-           a deep [OneArmAdded]/[OneArmRemoved] (path bubbles up through
-           [prepend_path]) or a leaf [OneArmReplaced { path = [] }] which
-           prepend_path turns into [{ path = [i] }]. A multi-arm give-up
-           below us also comes back as [OneArmReplaced { path = something }]
-           and prepend_path tags that path with [i]. *)
-        prepend_path i (analyze (List.nth ps1 i) (List.nth ps2 i))
-    | _ ->
-        (* More than one arm changed in-place. Give up at this level. *)
-        give_up
-  end
-  else if n < 0 then
-    (* ps1 was shorter; an insertion into ps1 could make ps2. *)
-    single_insert ps1 ps2 (fun ad -> OneArmAdded ad)
-  else
-    (* ps2 was shorter; equivalently, we can remove an arm from ps1 to make ps2. *)
-    single_insert ps2 ps1 (fun ad -> OneArmRemoved ad)
+  match List.compare_lengths ps1 ps2 with
+  | 0 -> begin
+      (* Same length. Exactly one slot differing means we recurse on it
+         (the inner diff might be deep — an [OneArmAdded]/[OneArmRemoved]
+         whose path bubbles up via [prepend_path], or a leaf
+         [OneArmReplaced { path = [] }] which [prepend_path] turns into
+         [{ path = [i] }]). Anything else is a multi-arm give-up. *)
+      match single_change ps1 ps2 with
+      | Some (i, _) ->
+          prepend_path i (analyze (List.nth ps1 i) (List.nth ps2 i))
+      | None -> if ps1 = ps2 then Same else give_up
+    end
+  | -1 -> begin
+      (* ps1 shorter; an insertion into ps1 could make ps2. *)
+      match single_insertion ps1 ps2 with
+      | Some (i, arm) -> OneArmAdded { path = [ i ]; arm }
+      | None -> give_up
+    end
+  | 1 -> begin
+      (* ps2 shorter; equivalently, an arm was removed from ps1. *)
+      match single_insertion ps2 ps1 with
+      | Some (i, arm) -> OneArmRemoved { path = [ i ]; arm }
+      | None -> give_up
+    end
+  | _ -> failwith "Can't get here"
 
-(* When the parents are WFQ, comparing their children is a little more complicated. *)
+(* When the parents are WFQ, comparing their children is a little more
+   complicated: a single clean edit must show up at the same index in
+   both the policy list and the weight list. *)
 and compare_wfq_children ~next:p2 ps1 (ws1 : float list) ps2 (ws2 : float list)
     =
   let give_up = OneArmReplaced { path = []; arm = p2 } in
-  match (ps1 = ps2, ws1 = ws2) with
-  | true, true -> Same (* Shoudn't get here; this is [Same] at a higher level *)
-  | false, true ->
-      (* We suspect it's a pure policy change in-place, with weights left 
-         unchanged. We can just pass this to [compare]. But first let's 
-         check if their lengths are the same *)
-      if List.length ps1 = List.length ps2 then
-        compare_children ~next:p2 ps1 ps2
-      else give_up
-  | true, false -> begin
-      (* Pure weight change in-place. [ps1 = ps2] guarantees the slot
-         counts match, so [ws1] and [ws2] are necessarily the same length
-         and [changes] is well-defined. The [[]] result is unreachable
-         because [ws1 <> ws2] in this branch. *)
-      match changes ws1 ws2 with
-      | [ (i, new_weight) ] -> WeightChanged { path = [ i ]; new_weight }
-      | _ ->
-          (* Detected more than one point of difference. We can't handle that yet. *)
-          give_up
+  match List.compare_lengths ps1 ps2 with
+  | 0 when ws1 = ws2 ->
+      (* Pure policy edit in-place; weights unchanged. Defer to the
+         non-WFQ comparator. *)
+      compare_children ~next:p2 ps1 ps2
+  | 0 when ps1 = ps2 -> begin
+      (* Pure weight edit in-place. Same slot counts ⇒ [changes] on the
+         weights is well-defined, and the empty result is unreachable
+         because [ws1 <> ws2] here. *)
+      match single_change ws1 ws2 with
+      | Some (i, new_weight) -> WeightChanged { path = [ i ]; new_weight }
+      | None -> give_up
     end
-  | false, false ->
-      (* Both lists changed. We can describe a single edit in three
-         shapes: an arm-add (one new slot in [next]), an arm-remove (one
-         dropped slot), or an arm-replace at one slot whose arm and
-         weight both changed. In each case the same slot index must
-         show up as the lone difference in both the policy list and
-         the weight list, confirming one consistent edit. *)
-      if List.length ps1 = List.length ps2 then begin
-        (* Same length: only a WFQ arm-replace can land here. The slot
-           must show as a single in-place difference in both [ps] and
-           [ws], and that slot's arm-vs-arm diff must itself be a
-           leaf-level replacement (otherwise we'd be folding a deep
-           arm change with a weight change into one variant, which
-           [Ir.patch] can't currently express). *)
-        match (changes ps1 ps2, changes ws1 ws2) with
-        | [ (i, _) ], [ (j, weight) ] when i = j -> begin
-            match analyze (List.nth ps1 i) (List.nth ps2 i) with
-            | OneArmReplaced { path = []; arm } ->
-                OneArmReplacedWFQ { path = [ i ]; arm; weight }
-            | _ -> give_up
-          end
-        | _ -> give_up
-      end
-      else begin
-        match (insertions ps1 ps2, insertions ws1 ws2) with
-        | Some [ (i, arm) ], Some [ (j, weight) ] when i = j ->
-            OneArmAddedWFQ { path = [ i ]; arm; weight }
-        | _ -> (
-            match (insertions ps2 ps1, insertions ws2 ws1) with
-            | Some [ (i, arm) ], Some [ (j, _) ] when i = j ->
-                OneArmRemoved { path = [ i ]; arm }
-            | _ -> give_up)
-      end
+  | 0 -> begin
+      (* Same length but both lists differ. The only single edit we could
+         describe is a WFQ arm-replace: one slot must be the lone
+         in-place difference in both [ps] and [ws], and the slot's
+         arm-vs-arm diff must itself be a leaf-level replacement
+         (otherwise we'd be folding a deep arm change with a weight
+         change into one variant, which [Ir.patch] can't express). *)
+      match single_change_lockstep ps1 ps2 ws1 ws2 with
+      | Some (i, _, weight) -> begin
+          match analyze (List.nth ps1 i) (List.nth ps2 i) with
+          | OneArmReplaced { path = []; arm } ->
+              OneArmReplacedWFQ { path = [ i ]; arm; weight }
+          | _ -> give_up
+        end
+      | None -> give_up
+    end
+  | -1 -> begin
+      (* ps1 shorter: a slot was added to make ps2, with its weight. *)
+      match single_insertion_lockstep ps1 ps2 ws1 ws2 with
+      | Some (i, arm, weight) -> OneArmAddedWFQ { path = [ i ]; arm; weight }
+      | None -> give_up
+    end
+  | 1 -> begin
+      (* ps2 shorter: a slot was removed from ps1. The dropped weight
+         isn't needed to describe the removal, so we use [OneArmRemoved]. *)
+      match single_insertion_lockstep ps2 ps1 ws2 ws1 with
+      | Some (i, arm, _) -> OneArmRemoved { path = [ i ]; arm }
+      | None -> give_up
+    end
+  | _ -> failwith "Can't get here"
 
 and analyze p1 p2 =
   if p1 = p2 then Same

--- a/rio/ir/decorated.ml
+++ b/rio/ir/decorated.ml
@@ -151,7 +151,11 @@ let insert_arm k new_step new_child = function
   | UNION (v, es) -> UNION (v, list_insert_at k (new_step, new_child) es)
   | SP (v, es) -> SP (v, list_insert_at k (new_step, new_child) es)
   | RR (v, es) -> RR (v, list_insert_at k (new_step, new_child) es)
-  | WFQ _ -> failwith "Decorated.insert_arm: WFQ unreachable under OneArmAdded"
+  | WFQ _ -> failwith "Decorated.insert_arm: WFQ — use insert_arm_wfq"
+
+let insert_arm_wfq k new_step new_child new_weight = function
+  | WFQ (v, es) -> WFQ (v, list_insert_at k (new_step, new_child, new_weight) es)
+  | _ -> failwith "Decorated.insert_arm_wfq: WFQ-only"
 
 let drop_arm k = function
   | FIFO _ -> failwith "Decorated.drop_arm: FIFO"

--- a/rio/ir/decorated.mli
+++ b/rio/ir/decorated.mli
@@ -62,7 +62,12 @@ val rewrite_at : t -> int list -> (t -> t) -> t
 val insert_arm : int -> step -> t -> t -> t
 (** [insert_arm k new_step new_child d] splices [new_child] in at index [k] in
     the children of [d], using [new_step] as the parent-to-child step. Errors on
-    FIFO and WFQ. *)
+    FIFO and WFQ; use [insert_arm_wfq] for WFQ. *)
+
+val insert_arm_wfq : int -> step -> t -> float -> t -> t
+(** [insert_arm_wfq k new_step new_child new_weight d] splices [new_child] in at
+    index [k] in the children of WFQ-rooted [d], pairing it with [new_step] and
+    [new_weight]. Errors on anything but WFQ. *)
 
 val drop_arm : int -> t -> t
 (** Remove the child at index [k]. Errors on FIFO. *)

--- a/rio/ir/ir.ml
+++ b/rio/ir/ir.ml
@@ -214,12 +214,12 @@ let pes_extended_to_depth target_depth pes =
    freshly compiled [arm]. Used both for whole-tree replacement (chain =
    [fake_chain], removed = prev.decorated) and for per-arm replacement
    (chain = ancestor_chain prev arm_path, removed = nth_child parent k).
-
    The parent never adopts the new root directly: [Designate] fuses the old
    and new roots into a super-node that occupies the existing slot, so
    in-flight traffic on the old root drains while new traffic goes to the
    new root via the same step. *)
-let replace_at ~prev ~chain ~removed ~arm_depth ~arm ~rewrite_decorated =
+let replace_at ~prev ~chain ~removed ~arm_depth ~arm ~rewrite_decorated
+    ?(extra_prog = []) () =
   let fresh_v, fresh_s = counters_after prev in
   let new_pes = pes_extended_to_depth (arm_depth + policy_depth arm) prev.pes in
   let pe_of_depth d = List.nth new_pes d in
@@ -237,23 +237,42 @@ let replace_at ~prev ~chain ~removed ~arm_depth ~arm ~rewrite_decorated =
         chain_emit (fun v _ c -> Deassoc (v, c)) chain removed_classes;
         chain_emit (fun v _ c -> Assoc (v, c)) chain arm_frag.classes;
         chain_emit (fun v s c -> Map (v, c, s)) chain arm_frag.classes;
+        extra_prog;
         gc_subtree removed;
       ]
   in
   Some { prog; decorated = rewrite_decorated arm_decorated; pes = new_pes }
 
-let patch_one_arm_replaced ~prev ~arm_path ~arm =
+(* WFQ slot replacement layers a slot weight bump on top of the plain
+   replacement: the existing parent→slot step is reused (so [Designate]
+   still fuses old/new on it), and we tack on a [Change_weight] for the
+   new weight plus a [set_weight] in the decorated rewrite. [wfq_weight]
+   is [Some w] iff this is a WFQ slot whose weight also changed. *)
+let patch_one_arm_replaced ~prev ~arm_path ~arm ~wfq_weight =
   let parent_path, k = list_foot arm_path in
   let parent = Decorated.walk prev.decorated parent_path in
-  replace_at ~prev ~chain:(Decorated.ancestor_chain prev.decorated arm_path)
+  let extra_prog, extra_rewrite =
+    match wfq_weight with
+    | None -> ([], fun d -> d)
+    | Some w ->
+        let parent_v = Decorated.root_vpifo parent in
+        let step_k = Decorated.nth_step parent k in
+        ([ Change_weight (parent_v, step_k, w) ], Decorated.set_weight k w)
+  in
+  replace_at ~prev
+    ~chain:(Decorated.ancestor_chain prev.decorated arm_path)
     ~removed:(Decorated.nth_child parent k)
-    ~arm_depth:(List.length arm_path) ~arm ~rewrite_decorated:(fun arm_d ->
-      Decorated.rewrite_at prev.decorated parent_path
-        (Decorated.replace_arm k arm_d))
+    ~arm_depth:(List.length arm_path) ~arm
+    ~rewrite_decorated:(fun arm_d ->
+      Decorated.rewrite_at prev.decorated parent_path (fun p ->
+          p |> Decorated.replace_arm k arm_d |> extra_rewrite))
+    ~extra_prog ()
 
 let patch_whole_tree_replace ~prev ~next =
   replace_at ~prev ~chain:fake_chain ~removed:prev.decorated ~arm_depth:0
-    ~arm:next ~rewrite_decorated:(fun d -> d)
+    ~arm:next
+    ~rewrite_decorated:(fun d -> d)
+    ()
 
 (* ------------------------------------------------------------------ *)
 (* Patch: weight change (WFQ-only, structure of tree unchanged.       *)
@@ -480,7 +499,9 @@ let patch ~prev ~(next : Frontend.Policy.t) : compiled option =
   | Same -> Some { prog = []; decorated = prev.decorated; pes = prev.pes }
   | OneArmReplaced { path = []; _ } -> patch_whole_tree_replace ~prev ~next
   | OneArmReplaced { path; arm } ->
-      patch_one_arm_replaced ~prev ~arm_path:path ~arm
+      patch_one_arm_replaced ~prev ~arm_path:path ~arm ~wfq_weight:None
+  | OneArmReplacedWFQ { path; arm; weight } ->
+      patch_one_arm_replaced ~prev ~arm_path:path ~arm ~wfq_weight:(Some weight)
   | OneArmAdded { path; arm } ->
       patch_one_arm_added ~prev ~arm_path:path ~arm ~wfq_weight:None
   | OneArmAddedWFQ { path; arm; weight } ->

--- a/rio/ir/ir.ml
+++ b/rio/ir/ir.ml
@@ -307,7 +307,12 @@ let sp_removed_weight_shifts ~parent_v ~parent ~k =
       if j > k then Some (Change_weight (parent_v, s, float_of_int j)) else None)
     (List.mapi (fun j e -> (j, e)) (sp_edges parent))
 
-let patch_one_arm_added ~prev ~arm_path ~arm =
+(* Single-arm insertion under [parent]. [wfq_weight] is [Some w] iff the
+   parent is a WFQ (the new slot rides with weight [w]).
+   The [Change_weight]s to emit and the decorated-tree update are the only 
+   things that vary by policy, so they are computed up front
+   and the rest of the body is shared between SP/UNION/RR/WFQ. *)
+let patch_one_arm_added ~prev ~arm_path ~arm ~wfq_weight =
   let parent_path, k = list_foot arm_path in
   let parent = Decorated.walk prev.decorated parent_path in
   let parent_v, old_arity, pol_ty = parent_info parent in
@@ -321,10 +326,18 @@ let patch_one_arm_added ~prev ~arm_path ~arm =
     compile_subtree ~fresh_v ~fresh_s ~pe_of_depth ~depth:arm_depth arm
   in
   let new_step = fresh_s () in
-  let change_weights =
-    match pol_ty with
-    | SP -> sp_inserted_weight_shifts ~parent_v ~parent ~k ~new_step
-    | _ -> []
+  let change_weights, decorated_update =
+    match (pol_ty, wfq_weight) with
+    | SP, None ->
+        ( sp_inserted_weight_shifts ~parent_v ~parent ~k ~new_step,
+          Decorated.insert_arm k new_step arm_decorated )
+    | WFQ, Some w ->
+        ( [ Change_weight (parent_v, new_step, w) ],
+          Decorated.insert_arm_wfq k new_step arm_decorated w )
+    | (UNION | RR), None -> ([], Decorated.insert_arm k new_step arm_decorated)
+    | _ ->
+        failwith
+          "Ir.patch.patch_one_arm_added: parent pol_ty / wfq_weight mismatch"
   in
   (* Strict ancestors above [parent_v] reuse their existing step toward
      [parent_v]; [parent_v] itself uses the freshly minted [new_step]. *)
@@ -345,54 +358,7 @@ let patch_one_arm_added ~prev ~arm_path ~arm =
     }
   in
   let new_decorated =
-    Decorated.rewrite_at prev.decorated parent_path
-      (Decorated.insert_arm k new_step arm_decorated)
-  in
-  Some
-    {
-      prog = Frag.to_program (Frag.combine local [ arm_frag ]);
-      decorated = new_decorated;
-      pes = new_pes;
-    }
-
-(* WFQ counterpart to [patch_one_arm_added]: the parent is a WFQ, so the new
-   slot rides with a [weight] that we install via [Change_weight] on the
-   freshly minted step. No SP-style positional weight shifts happen — WFQ
-   weights are independent per slot. *)
-let patch_one_arm_added_wfq ~prev ~arm_path ~arm ~weight =
-  let parent_path, k = list_foot arm_path in
-  let parent = Decorated.walk prev.decorated parent_path in
-  let parent_v, old_arity, pol_ty = parent_info parent in
-  (match pol_ty with
-  | WFQ -> ()
-  | _ -> failwith "Ir.patch: OneArmAddedWFQ parent is not a WFQ");
-  let fresh_v, fresh_s = counters_after prev in
-  let arm_depth = List.length arm_path in
-  let new_pes = pes_extended_to_depth (arm_depth + policy_depth arm) prev.pes in
-  let pe_of_depth d = List.nth new_pes d in
-  let arm_frag, arm_decorated =
-    compile_subtree ~fresh_v ~fresh_s ~pe_of_depth ~depth:arm_depth arm
-  in
-  let new_step = fresh_s () in
-  let chain =
-    Decorated.ancestor_chain prev.decorated parent_path
-    @ [ (parent_v, new_step) ]
-  in
-  let local : Frag.t =
-    {
-      spawns = [];
-      adopts = [ Adopt (new_step, parent_v, arm_frag.root_v) ];
-      assocs = chain_emit (fun v _ c -> Assoc (v, c)) chain arm_frag.classes;
-      maps = chain_emit (fun v s c -> Map (v, c, s)) chain arm_frag.classes;
-      change_pols = [ Change_pol (parent_v, pol_ty, old_arity + 1) ];
-      change_weights = [ Change_weight (parent_v, new_step, weight) ];
-      root_v = parent_v;
-      classes = arm_frag.classes;
-    }
-  in
-  let new_decorated =
-    Decorated.rewrite_at prev.decorated parent_path
-      (Decorated.insert_arm_wfq k new_step arm_decorated weight)
+    Decorated.rewrite_at prev.decorated parent_path decorated_update
   in
   Some
     {
@@ -515,9 +481,10 @@ let patch ~prev ~(next : Frontend.Policy.t) : compiled option =
   | OneArmReplaced { path = []; _ } -> patch_whole_tree_replace ~prev ~next
   | OneArmReplaced { path; arm } ->
       patch_one_arm_replaced ~prev ~arm_path:path ~arm
-  | OneArmAdded { path; arm } -> patch_one_arm_added ~prev ~arm_path:path ~arm
+  | OneArmAdded { path; arm } ->
+      patch_one_arm_added ~prev ~arm_path:path ~arm ~wfq_weight:None
   | OneArmAddedWFQ { path; arm; weight } ->
-      patch_one_arm_added_wfq ~prev ~arm_path:path ~arm ~weight
+      patch_one_arm_added ~prev ~arm_path:path ~arm ~wfq_weight:(Some weight)
   | OneArmRemoved { path; arm = _ } ->
       patch_one_arm_removed ~prev ~arm_path:path
   | WeightChanged { path; new_weight } ->

--- a/rio/ir/ir.ml
+++ b/rio/ir/ir.ml
@@ -355,6 +355,52 @@ let patch_one_arm_added ~prev ~arm_path ~arm =
       pes = new_pes;
     }
 
+(* WFQ counterpart to [patch_one_arm_added]: the parent is a WFQ, so the new
+   slot rides with a [weight] that we install via [Change_weight] on the
+   freshly minted step. No SP-style positional weight shifts happen — WFQ
+   weights are independent per slot. *)
+let patch_one_arm_added_wfq ~prev ~arm_path ~arm ~weight =
+  let parent_path, k = list_foot arm_path in
+  let parent = Decorated.walk prev.decorated parent_path in
+  let parent_v, old_arity, pol_ty = parent_info parent in
+  (match pol_ty with
+  | WFQ -> ()
+  | _ -> failwith "Ir.patch: OneArmAddedWFQ parent is not a WFQ");
+  let fresh_v, fresh_s = counters_after prev in
+  let arm_depth = List.length arm_path in
+  let new_pes = pes_extended_to_depth (arm_depth + policy_depth arm) prev.pes in
+  let pe_of_depth d = List.nth new_pes d in
+  let arm_frag, arm_decorated =
+    compile_subtree ~fresh_v ~fresh_s ~pe_of_depth ~depth:arm_depth arm
+  in
+  let new_step = fresh_s () in
+  let chain =
+    Decorated.ancestor_chain prev.decorated parent_path
+    @ [ (parent_v, new_step) ]
+  in
+  let local : Frag.t =
+    {
+      spawns = [];
+      adopts = [ Adopt (new_step, parent_v, arm_frag.root_v) ];
+      assocs = chain_emit (fun v _ c -> Assoc (v, c)) chain arm_frag.classes;
+      maps = chain_emit (fun v s c -> Map (v, c, s)) chain arm_frag.classes;
+      change_pols = [ Change_pol (parent_v, pol_ty, old_arity + 1) ];
+      change_weights = [ Change_weight (parent_v, new_step, weight) ];
+      root_v = parent_v;
+      classes = arm_frag.classes;
+    }
+  in
+  let new_decorated =
+    Decorated.rewrite_at prev.decorated parent_path
+      (Decorated.insert_arm_wfq k new_step arm_decorated weight)
+  in
+  Some
+    {
+      prog = Frag.to_program (Frag.combine local [ arm_frag ]);
+      decorated = new_decorated;
+      pes = new_pes;
+    }
+
 let patch_one_arm_removed ~prev ~arm_path =
   let parent_path, k = list_foot arm_path in
   let parent = Decorated.walk prev.decorated parent_path in
@@ -470,6 +516,8 @@ let patch ~prev ~(next : Frontend.Policy.t) : compiled option =
   | OneArmReplaced { path; arm } ->
       patch_one_arm_replaced ~prev ~arm_path:path ~arm
   | OneArmAdded { path; arm } -> patch_one_arm_added ~prev ~arm_path:path ~arm
+  | OneArmAddedWFQ { path; arm; weight } ->
+      patch_one_arm_added_wfq ~prev ~arm_path:path ~arm ~weight
   | OneArmRemoved { path; arm = _ } ->
       patch_one_arm_removed ~prev ~arm_path:path
   | WeightChanged { path; new_weight } ->

--- a/rio/ir/ir.ml
+++ b/rio/ir/ir.ml
@@ -218,8 +218,7 @@ let pes_extended_to_depth target_depth pes =
    and new roots into a super-node that occupies the existing slot, so
    in-flight traffic on the old root drains while new traffic goes to the
    new root via the same step. *)
-let replace_at ~prev ~chain ~removed ~arm_depth ~arm ~rewrite_decorated
-    ?(extra_prog = []) () =
+let replace_at ~prev ~chain ~removed ~arm_depth ~arm ~rewrite_decorated =
   let fresh_v, fresh_s = counters_after prev in
   let new_pes = pes_extended_to_depth (arm_depth + policy_depth arm) prev.pes in
   let pe_of_depth d = List.nth new_pes d in
@@ -237,42 +236,35 @@ let replace_at ~prev ~chain ~removed ~arm_depth ~arm ~rewrite_decorated
         chain_emit (fun v _ c -> Deassoc (v, c)) chain removed_classes;
         chain_emit (fun v _ c -> Assoc (v, c)) chain arm_frag.classes;
         chain_emit (fun v s c -> Map (v, c, s)) chain arm_frag.classes;
-        extra_prog;
         gc_subtree removed;
       ]
   in
-  Some { prog; decorated = rewrite_decorated arm_decorated; pes = new_pes }
+  { prog; decorated = rewrite_decorated arm_decorated; pes = new_pes }
 
-(* WFQ slot replacement layers a slot weight bump on top of the plain
-   replacement: the existing parent→slot step is reused (so [Designate]
-   still fuses old/new on it), and we tack on a [Change_weight] for the
-   new weight plus a [set_weight] in the decorated rewrite. [wfq_weight]
-   is [Some w] iff this is a WFQ slot whose weight also changed. *)
 let patch_one_arm_replaced ~prev ~arm_path ~arm ~wfq_weight =
   let parent_path, k = list_foot arm_path in
   let parent = Decorated.walk prev.decorated parent_path in
-  let extra_prog, extra_rewrite =
+  let weight_prog, weight_rewrite =
     match wfq_weight with
-    | None -> ([], fun d -> d)
+    | None -> ([], Fun.id)
     | Some w ->
         let parent_v = Decorated.root_vpifo parent in
         let step_k = Decorated.nth_step parent k in
         ([ Change_weight (parent_v, step_k, w) ], Decorated.set_weight k w)
   in
-  replace_at ~prev
-    ~chain:(Decorated.ancestor_chain prev.decorated arm_path)
-    ~removed:(Decorated.nth_child parent k)
-    ~arm_depth:(List.length arm_path) ~arm
-    ~rewrite_decorated:(fun arm_d ->
-      Decorated.rewrite_at prev.decorated parent_path (fun p ->
-          p |> Decorated.replace_arm k arm_d |> extra_rewrite))
-    ~extra_prog ()
+  let c =
+    replace_at ~prev ~chain:(Decorated.ancestor_chain prev.decorated arm_path)
+      ~removed:(Decorated.nth_child parent k)
+      ~arm_depth:(List.length arm_path) ~arm ~rewrite_decorated:(fun arm_d ->
+        Decorated.rewrite_at prev.decorated parent_path (fun p ->
+            p |> Decorated.replace_arm k arm_d |> weight_rewrite))
+  in
+  Some { c with prog = c.prog @ weight_prog }
 
 let patch_whole_tree_replace ~prev ~next =
-  replace_at ~prev ~chain:fake_chain ~removed:prev.decorated ~arm_depth:0
-    ~arm:next
-    ~rewrite_decorated:(fun d -> d)
-    ()
+  Some
+    (replace_at ~prev ~chain:fake_chain ~removed:prev.decorated ~arm_depth:0
+       ~arm:next ~rewrite_decorated:Fun.id)
 
 (* ------------------------------------------------------------------ *)
 (* Patch: weight change (WFQ-only, structure of tree unchanged.       *)
@@ -326,11 +318,7 @@ let sp_removed_weight_shifts ~parent_v ~parent ~k =
       if j > k then Some (Change_weight (parent_v, s, float_of_int j)) else None)
     (List.mapi (fun j e -> (j, e)) (sp_edges parent))
 
-(* Single-arm insertion under [parent]. [wfq_weight] is [Some w] iff the
-   parent is a WFQ (the new slot rides with weight [w]).
-   The [Change_weight]s to emit and the decorated-tree update are the only 
-   things that vary by policy, so they are computed up front
-   and the rest of the body is shared between SP/UNION/RR/WFQ. *)
+(* Single-arm insertion under [parent]. *)
 let patch_one_arm_added ~prev ~arm_path ~arm ~wfq_weight =
   let parent_path, k = list_foot arm_path in
   let parent = Decorated.walk prev.decorated parent_path in

--- a/rio/tests/frontend/test_compare.ml
+++ b/rio/tests/frontend/test_compare.ml
@@ -140,6 +140,19 @@ let onearmreplaced =
       (OneArmReplaced { path = [ 2 ]; arm = Policy.FIFO "Z" });
   ]
 
+(* OneArmReplacedWFQ: a single WFQ slot's arm and weight both changed.
+   Detected when policy and weight lists each have exactly one
+   in-place divergence at the same slot, and the slot's arm-vs-arm
+   diff itself is a leaf-level [OneArmReplaced]. *)
+let one_arm_replaced_wfq =
+  [
+    (* WFQ(A:2,B:1,C:3) → WFQ(A:2,B:1,Z:7): slot 2's arm flipped C→Z and
+       weight 3→7 in the same edit. *)
+    make_compare_test "WFQ slot with arm change and weight change" "wfq_ABC"
+      "wfq_ABZ_diff"
+      (OneArmReplacedWFQ { path = [ 2 ]; arm = Policy.FIFO "Z"; weight = 7.0 });
+  ]
+
 let superpol =
   [
     make_compare_test "fifo_G is sub-pol of union[G,H]" "fifo_G" "union_GH"
@@ -182,11 +195,6 @@ let verydiff_combos =
        [WeightChanged]) at the same slot. *)
     make_giveup_test "WFQ slot with deep diff and weight change" "wfq_complex"
       "wfq_complex_deep_and_weight" [];
-    (* WFQ(A:2,B:1,C:3) → WFQ(A:2,B:1,Z:7): one slot's arm changed
-       (C→Z, an [OneArmReplaced]) and its weight changed (3→7, a
-       [WeightChanged]). Same slot, two distinct edits. *)
-    make_giveup_test "WFQ slot with arm change and weight change" "wfq_ABC"
-      "wfq_ABZ_diff" [];
     (* RR(A,B) → RR(D,B,A,SP(C,E)): two new arms (D and SP[C,E]) — a
        multi-arm add, hence two [OneArmAdded]s. *)
     make_giveup_test "RR with two arms added whilst reordering" "rr_AB"
@@ -223,6 +231,7 @@ let verydiff_combos =
 let suite =
   "compare tests"
   >::: same @ one_arm_added @ one_arm_added_wfq @ armsremoved @ weightchanged
-       @ onearmreplaced @ verydiff_combos @ superpol @ subpol
+       @ onearmreplaced @ one_arm_replaced_wfq @ verydiff_combos @ superpol
+       @ subpol
 
 let () = run_test_tt_main suite

--- a/rio/tests/frontend/test_compare.ml
+++ b/rio/tests/frontend/test_compare.ml
@@ -38,9 +38,8 @@ let same =
 
 (* OneArmAdded fires on a single-arm insertion at any position of a
    UNION/RR/SP parent (after [Policy.normalize] has sorted UNION/RR
-   children). WFQ-add does *not* land here — see [verydiff_combos] —
-   because the new slot's weight can't ride along on [arm_diff], so a
-   WFQ-add is logically [OneArmAdded + WeightChanged]. 
+   children). WFQ-add lands in the dedicated [OneArmAddedWFQ] variant
+   (see [one_arm_added_wfq]) since the new slot also carries a weight.
    Multi-arm insertions instead "give up" to a wholesale-replace
    [OneArmReplaced] (see [verydiff_combos]). The
    [path] inside [arm_diff] is the new arm's full position from the
@@ -72,6 +71,31 @@ let one_arm_added =
     make_compare_test "complex tree add arm deep" "complex_tree"
       "complex_tree_add_arm_deep"
       (OneArmAdded { path = [ 2; 3 ]; arm = Policy.FIFO "NEW" });
+  ]
+
+(* OneArmAddedWFQ: a WFQ parent gains exactly one slot. Detected when the
+   policy list and the weight list each show a single insertion at the
+   same index. The carried [weight] is the new slot's weight in [next]. *)
+let one_arm_added_wfq =
+  [
+    (* WFQ(B,A) → WFQ(A:2,B:1,C:3): after normalize the prev pairs sort to
+       [(A,2),(B,1)] and next to [(A,2),(B,1),(C,3)]. The C slot is the
+       lone insertion (index 2, weight 3). *)
+    make_compare_test "WFQ with arm added at end" "wfq_BA" "wfq_ABC"
+      (OneArmAddedWFQ { path = [ 2 ]; arm = Policy.FIFO "C"; weight = 3.0 });
+    (* complex_tree_partial → complex_tree: at the root WFQ a new
+       (rr[D,E,F], 2) slot appears. Children sort by variant tag
+       (UNION < SP < RR), so prev pairs are [(UNION,3),(SP,1)] and next
+       pairs are [(UNION,3),(SP,1),(RR,2)]: insertion at index 2,
+       weight 2. *)
+    make_compare_test "complex tree fill in missing arm" "complex_tree_partial"
+      "complex_tree"
+      (OneArmAddedWFQ
+         {
+           path = [ 2 ];
+           arm = Policy.RR [ Policy.FIFO "D"; Policy.FIFO "E"; Policy.FIFO "F" ];
+           weight = 2.0;
+         });
   ]
 
 let armsremoved =
@@ -163,15 +187,6 @@ let verydiff_combos =
        [WeightChanged]). Same slot, two distinct edits. *)
     make_giveup_test "WFQ slot with arm change and weight change" "wfq_ABC"
       "wfq_ABZ_diff" [];
-    (* WFQ(B,A) → WFQ(A:2,B:1,C:3): adding a WFQ arm is logically
-       [OneArmAdded] (the arm) + [WeightChanged] (the new slot's
-       weight). [arm_diff] no longer carries a weight, so this combo
-       can't fold into a single variant. *)
-    make_giveup_test "WFQ with arm added" "wfq_BA" "wfq_ABC" [];
-    (* complex_tree_partial → complex_tree: a WFQ-level arm-add at the
-       root (the RR subtree, weight 2). Same combo as above. *)
-    make_giveup_test "complex tree fill in missing arm" "complex_tree_partial"
-      "complex_tree" [];
     (* RR(A,B) → RR(D,B,A,SP(C,E)): two new arms (D and SP[C,E]) — a
        multi-arm add, hence two [OneArmAdded]s. *)
     make_giveup_test "RR with two arms added whilst reordering" "rr_AB"
@@ -207,7 +222,7 @@ let verydiff_combos =
 
 let suite =
   "compare tests"
-  >::: same @ one_arm_added @ armsremoved @ weightchanged @ onearmreplaced
-       @ verydiff_combos @ superpol @ subpol
+  >::: same @ one_arm_added @ one_arm_added_wfq @ armsremoved @ weightchanged
+       @ onearmreplaced @ verydiff_combos @ superpol @ subpol
 
 let () = run_test_tt_main suite

--- a/rio/tests/ir/test_patch.ml
+++ b/rio/tests/ir/test_patch.ml
@@ -274,8 +274,8 @@ let wfq_abc_to_abz_diff_expected : program =
     Deassoc (100, "C");
     Assoc (100, "Z");
     Map (100, "Z", 1002);
-    Change_weight (100, 1002, 7.0);
     GC 103;
+    Change_weight (100, 1002, 7.0);
   ]
 
 let one_arm_replaced_wfq_tests =

--- a/rio/tests/ir/test_patch.ml
+++ b/rio/tests/ir/test_patch.ml
@@ -259,6 +259,31 @@ let one_arm_replaced_tests =
       strict_ab_to_ac_expected;
   ]
 
+(* OneArmReplacedWFQ. wfq_ABC has root WFQ v=100 with leaves v=101/102/103
+   for A/B/C on steps 1000/1001/1002. Replacing slot 2's arm (C → FIFO Z)
+   *and* its weight (3 → 7) reuses step 1002: the new FIFO Z spawns on
+   v=104 (PE 1), is [Designate]d onto v=103, ancestor routing on v=100
+   swings C → Z, the slot's weight gets a single [Change_weight], and
+   v=103 is GC'd. *)
+let wfq_abc_to_abz_diff_expected : program =
+  [
+    Spawn (104, 1);
+    Assoc (104, "Z");
+    Designate (103, 104);
+    Unmap (100, "C", 1002);
+    Deassoc (100, "C");
+    Assoc (100, "Z");
+    Map (100, "Z", 1002);
+    Change_weight (100, 1002, 7.0);
+    GC 103;
+  ]
+
+let one_arm_replaced_wfq_tests =
+  [
+    make_delta_test "wfq[A,B,C] -> wfq[A,B,Z(7)]" "wfq_ABC" "wfq_ABZ_diff"
+      wfq_abc_to_abz_diff_expected;
+  ]
+
 (* Whole-tree replacement (Compare returns [VeryDifferent []]). prev =
    rr[A,B] (vpifos 100/101/102, steps 1000/1001); next = rr[D,E,F] which
    shares no arms, so Compare gives up at the root. The patch builds the
@@ -539,7 +564,7 @@ let suite =
   "patch tests"
   >::: one_arm_added_tests @ one_arm_added_wfq_tests @ weight_changed_tests
        @ one_arm_removed_tests @ one_arm_replaced_tests
-       @ whole_tree_replace_tests @ sub_pol_tests @ super_pol_tests
-       @ pes_extension_tests @ deep_giveup_tests
+       @ one_arm_replaced_wfq_tests @ whole_tree_replace_tests @ sub_pol_tests
+       @ super_pol_tests @ pes_extension_tests @ deep_giveup_tests
 
 let () = run_test_tt_main suite

--- a/rio/tests/ir/test_patch.ml
+++ b/rio/tests/ir/test_patch.ml
@@ -96,6 +96,72 @@ let one_arm_added_tests =
       "complex_tree_add_arm_deep" complex_tree_add_deep_expected;
   ]
 
+(* OneArmAddedWFQ *)
+
+(* wfq_BA compiles with vpifos 100 (root WFQ), 101 (A), 102 (B); steps 1000
+   (A), 1001 (B). Adding FIFO C at slot 2 with weight 3 mints v=103 (PE 1)
+   and step 1002, plus a single Change_weight on the new step (no SP-style
+   shifts: WFQ slots are independent). *)
+let wfq_ba_to_abc_expected : program =
+  [
+    Spawn (103, 1);
+    Adopt (1002, 100, 103);
+    Assoc (100, "C");
+    Assoc (103, "C");
+    Map (100, "C", 1002);
+    Change_pol (100, WFQ, 3);
+    Change_weight (100, 1002, 3.0);
+  ]
+
+(* complex_tree_partial: WFQ at root with two children — UNION[G,H] (weight 3)
+   and SP[A,B,C] (weight 1). After normalize: pairs sort by variant tag
+   (UNION < SP), giving children at indices 0, 1.
+     v=100 root WFQ; v=101 UNION; v=102 G; v=103 H; v=104 SP; v=105/106/107
+     A/B/C. Steps: 1000 (root→UNION), 1001/1002 (UNION→G/H), 1003
+     (root→SP), 1004/1005/1006 (SP→A/B/C). pes=[0;1;2].
+   Patch adds the RR[D,E,F] subtree with weight 2 at slot 2: arm internals
+   land on v=108 (RR, PE 1) plus 109/110/111 (D/E/F, PE 2); arm-internal
+   adopts on steps 1007/1008/1009. The new parent→child step is 1010, with
+   Change_weight(100, 1010, 2.0). *)
+let complex_tree_partial_to_full_expected : program =
+  [
+    Spawn (108, 1);
+    Spawn (109, 2);
+    Spawn (110, 2);
+    Spawn (111, 2);
+    Adopt (1010, 100, 108);
+    Adopt (1007, 108, 109);
+    Adopt (1008, 108, 110);
+    Adopt (1009, 108, 111);
+    Assoc (100, "D");
+    Assoc (100, "E");
+    Assoc (100, "F");
+    Assoc (108, "D");
+    Assoc (108, "E");
+    Assoc (108, "F");
+    Assoc (109, "D");
+    Assoc (110, "E");
+    Assoc (111, "F");
+    Map (100, "D", 1010);
+    Map (100, "E", 1010);
+    Map (100, "F", 1010);
+    Map (108, "D", 1007);
+    Map (108, "E", 1008);
+    Map (108, "F", 1009);
+    Change_pol (100, WFQ, 3);
+    Change_pol (108, RR, 3);
+    Change_weight (100, 1010, 2.0);
+  ]
+
+let one_arm_added_wfq_tests =
+  [
+    make_delta_test "wfq[B,A] -> wfq[A,B,C]" "wfq_BA" "wfq_ABC"
+      wfq_ba_to_abc_expected;
+    make_delta_test "complex_tree_partial -> complex_tree"
+      "complex_tree_partial" "complex_tree"
+      complex_tree_partial_to_full_expected;
+  ]
+
 (* WeightChanged *)
 
 (* WFQ root with three FIFO arms: vpifo IDs 100 (root), 101/102/103 (A/B/C);
@@ -471,8 +537,9 @@ let deep_giveup_tests = [ deep_giveup_test ]
 
 let suite =
   "patch tests"
-  >::: one_arm_added_tests @ weight_changed_tests @ one_arm_removed_tests
-       @ one_arm_replaced_tests @ whole_tree_replace_tests @ sub_pol_tests
-       @ super_pol_tests @ pes_extension_tests @ deep_giveup_tests
+  >::: one_arm_added_tests @ one_arm_added_wfq_tests @ weight_changed_tests
+       @ one_arm_removed_tests @ one_arm_replaced_tests
+       @ whole_tree_replace_tests @ sub_pol_tests @ super_pol_tests
+       @ pes_extension_tests @ deep_giveup_tests
 
 let () = run_test_tt_main suite


### PR DESCRIPTION
In #105 we explored making `compare.ml` output a _list_ of changes, which `ir.ml` would run over to generate a big patch that accomplishes all of those changes in IL. In 105 we only used this new power to handle WFQ arm addition and WFQ arm replacement. Any other actually complicated things (e.g., add an arm here, replace an arm there, then we are a sub-pol of that) were left for future work.

This PR is an illustration of the other route that we could have taken instead of #105. We just have two new variants in `compare.ml` that capture the two WFQ-specific changes. Now that the meaning of a change is a little expanded, `compare.ml` can get by with still emitting only _one_ change. Correspondingly, `ir.ml` has been taught how to deal with these two new emissions from `compare.ml`. 

This has a smaller "splash zone" than #105 and lets us at least handle the last remaining simple-feeling changes without unnecessarily wading into _lists of changes_ and then using only a tiny amount of that list-ey power. Strictly speaking this work is of course less powerful than #105. And yet I suggest we merge this instead of merging #105.