### PR TITLE
Make SuperPol and SubPol only fire for whole-tree sightings

### DIFF
--- a/rio/compare/compare.ml
+++ b/rio/compare/compare.ml
@@ -17,8 +17,16 @@ type t =
     (* WFQ-specific arm replacement: a single WFQ slot's arm and weight
        both changed. Bundles the new arm and the new weight together so
        it doesn't decompose into [OneArmReplaced] + [WeightChanged]. *)
-  | SuperPol of path (* [path] points to [prev] inside [next]. *)
-  | SubPol of path (* [path] points to [next] inside [prev]. *)
+  | SuperPol of path
+    (* [SuperPol]/[SubPol] are only emitted at the top level of [analyze]:
+       [SuperPol path] means [path] points to [prev] inside [next];
+       [SubPol path] means [path] points to [next] inside [prev]. When
+       nested comparisons would otherwise bubble one of these up through
+       [compare_children], we demote to [OneArmReplaced] at the differing
+       slot — the inner sub-policy path would no longer describe "prev
+       sits inside next" (or vice versa), just "child1 sits inside
+       child2", which is not actionable from [Ir.patch]. *)
+  | SubPol of path
 
 and arm_diff = {
   path : path;
@@ -163,7 +171,20 @@ and compare_children ~next:p2 ps1 ps2 =
          [{ path = [i] }]). Anything else is a multi-arm give-up. *)
       begin match single_change ps1 ps2 with
       | Some (i, _) ->
-          prepend_path i (analyze (List.nth ps1 i) (List.nth ps2 i))
+          let child1 = List.nth ps1 i in
+          let child2 = List.nth ps2 i in
+          let inner =
+            match analyze child1 child2 with
+            | SuperPol _ | SubPol _ ->
+                (* A nested [SuperPol]/[SubPol] only says "child1 embeds in
+                   child2" (or vice versa) — it does NOT say "prev embeds
+                   in next" at the outer position, so bubbling it up with
+                   [prepend_path] would mis-describe the edit. Demote to a
+                   wholesale slot replacement. *)
+                OneArmReplaced { path = []; arm = child2 }
+            | d -> d
+          in
+          prepend_path i inner
       | None -> if ps1 = ps2 then Same else give_up
       end
   | -1 ->

--- a/rio/tests/frontend/test_compare.ml
+++ b/rio/tests/frontend/test_compare.ml
@@ -150,6 +150,30 @@ let one_arm_replaced_wfq =
       (OneArmReplacedWFQ { path = [ 2 ]; arm = Policy.FIFO "Z"; weight = 7.0 });
   ]
 
+(* Nested-recursion regression tests for #112. When [compare_children]
+   recurses into a single differing slot and the child's [analyze] returns
+   [SuperPol]/[SubPol], the path inside that variant only describes the
+   inner embedding (child1 inside child2 or vice versa) — NOT the
+   whole-prev embedding the variant documents at the top level. We demote
+   such results to [OneArmReplaced] at the slot, so [Ir.patch] can act on
+   them. *)
+let nested_superpol_subpol_demotion =
+  [
+    (* SP(A, B) vs SP(A, rr[B, C]): at the differing slot 1, the inner
+       analyze(B, rr[B, C]) yields SuperPol [0]. Pre-fix, this bubbled up
+       as SuperPol [1; 0], whose path does not point to prev inside next.
+       Now demoted to OneArmReplaced { path = [1]; arm = rr[B, C] }. *)
+    make_compare_test "nested SuperPol demotes to OneArmReplaced" "strict_AB"
+      "strict_A_rrBC"
+      (OneArmReplaced
+         { path = [ 1 ]; arm = Policy.RR [ Policy.FIFO "B"; Policy.FIFO "C" ] });
+    (* Inverse: SP(A, rr[B, C]) vs SP(A, B). Inner analyze yields SubPol [0];
+       demoted to OneArmReplaced { path = [1]; arm = B }. *)
+    make_compare_test "nested SubPol demotes to OneArmReplaced" "strict_A_rrBC"
+      "strict_AB"
+      (OneArmReplaced { path = [ 1 ]; arm = Policy.FIFO "B" });
+  ]
+
 let superpol =
   [
     make_compare_test "fifo_G is sub-pol of union[G,H]" "fifo_G" "union_GH"
@@ -229,6 +253,6 @@ let suite =
   "compare tests"
   >::: same @ one_arm_added @ one_arm_added_wfq @ armsremoved @ weightchanged
        @ onearmreplaced @ one_arm_replaced_wfq @ verydiff_combos @ superpol
-       @ subpol
+       @ subpol @ nested_superpol_subpol_demotion
 
 let () = run_test_tt_main suite

--- a/rio/tests/progs/work_conserving/strict_A_rrBC.sched
+++ b/rio/tests/progs/work_conserving/strict_A_rrBC.sched
@@ -1,0 +1,5 @@
+classes A, B, C;
+
+policy = strict[A, rr[B, C]];
+
+return policy


### PR DESCRIPTION
I noticed that, given the following transition:

```
prev = SP(gmail, zoom)
next = SP(gmail, RR(zoom, spotify))
```
we were calling this a `SuperPol [1; 0]`. This was a somewhat garbled attempt to say that `zoom` is inside of `RR(zoom, spotify)`. We are potentially interested in this sort of delicate wrap-job in the future (see #91) but for now the intention was that `SuperPol` and `SubPol` would only fire when the entire old/new tree was found within the entire new/old tree. 

This PR makes it so, and adds the above example as a pair of new tests. In so doing, it closes #112.