### PR TITLE
Tweak ADT arm names

### DIFF
--- a/rio/compare/compare.ml
+++ b/rio/compare/compare.ml
@@ -5,24 +5,24 @@ type path = int list
 (* A structural diff between two policies. *)
 type t =
   | Same
-  | OneArmAdded of arm_diff
-  | OneArmAddedWFQ of arm_diff_w
+  | ArmAdded of arm_diff
+  | ArmAddedWFQ of arm_diff_w
     (* WFQ-specific arm addition. Adding a slot to a WFQ parent always
        carries a weight, so the new arm and its weight are a single edit. *)
-  | OneArmRemoved of arm_diff
+  | ArmRemoved of arm_diff
   | WeightChanged of weight_change
-  | OneArmReplaced of arm_diff
+  | ArmReplaced of arm_diff
     (* Wholesale replacement of the subtree at [path] with [arm]. If [path] is nil, that means we're not (yet) clever enough to specify the change and the arm being replaced is the whole tree. *)
-  | OneArmReplacedWFQ of arm_diff_w
+  | ArmReplacedWFQ of arm_diff_w
     (* WFQ-specific arm replacement: a single WFQ slot's arm and weight
        both changed. Bundles the new arm and the new weight together so
-       it doesn't decompose into [OneArmReplaced] + [WeightChanged]. *)
+       it doesn't decompose into [ArmReplaced] + [WeightChanged]. *)
   | SuperPol of path
     (* [SuperPol]/[SubPol] are only emitted at the top level of [analyze]:
        [SuperPol path] means [path] points to [prev] inside [next];
        [SubPol path] means [path] points to [next] inside [prev]. When
        nested comparisons would otherwise bubble one of these up through
-       [compare_children], we demote to [OneArmReplaced] at the differing
+       [compare_children], we demote to [ArmReplaced] at the differing
        slot — the inner sub-policy path would no longer describe "prev
        sits inside next" (or vice versa), just "child1 sits inside
        child2", which is not actionable from [Ir.patch]. *)
@@ -31,8 +31,8 @@ type t =
 and arm_diff = {
   path : path;
       (* Path from the root to the position of this arm.
-      For [OneArmAdded] this is a position in *next*; for
-          [OneArmRemoved] it is a position in *prev*. *)
+      For [ArmAdded] this is a position in *next*; for
+          [ArmRemoved] it is a position in *prev*. *)
   arm : Rio_core.Policy.t;
 }
 
@@ -120,12 +120,12 @@ let prepend_path i diff =
   let prepend_wc (wc : weight_change) = { wc with path = i :: wc.path } in
   match diff with
   | Same -> Same
-  | OneArmAdded ad -> OneArmAdded (prepend_arm ad)
-  | OneArmAddedWFQ ad -> OneArmAddedWFQ (prepend_arm_w ad)
-  | OneArmRemoved ad -> OneArmRemoved (prepend_arm ad)
+  | ArmAdded ad -> ArmAdded (prepend_arm ad)
+  | ArmAddedWFQ ad -> ArmAddedWFQ (prepend_arm_w ad)
+  | ArmRemoved ad -> ArmRemoved (prepend_arm ad)
   | WeightChanged wc -> WeightChanged (prepend_wc wc)
-  | OneArmReplaced ad -> OneArmReplaced (prepend_arm ad)
-  | OneArmReplacedWFQ ad -> OneArmReplacedWFQ (prepend_arm_w ad)
+  | ArmReplaced ad -> ArmReplaced (prepend_arm ad)
+  | ArmReplacedWFQ ad -> ArmReplacedWFQ (prepend_arm_w ad)
   | SuperPol p -> SuperPol (i :: p)
   | SubPol p -> SubPol (i :: p)
 
@@ -152,22 +152,22 @@ let rec is_sub_policy p1 p2 =
 
 (* We arrive here when two parents have the same policy, so we now need to
    compare their children against each other. 
-   [OneArmAdded] only fires when exactly one arm was inserted; 
-   [OneArmRemoved] only when exactly one was dropped; 
+   [ArmAdded] only fires when exactly one arm was inserted; 
+   [ArmRemoved] only when exactly one was dropped; 
    a single in-place divergence recurses into the differing children 
    (this is how deep diffs get recognized: the inner [analyze]
    returns a parent-relative diff and we tack on [i] using [prepend_path]).
    When the sniffer can't break the change down at this level (multi-arm
    divergence, mismatched insertions, etc.), we "give up" by emitting
-   [OneArmReplaced { path = []; arm = p2 }]. *)
+   [ArmReplaced { path = []; arm = p2 }]. *)
 and compare_children ~next:p2 ps1 ps2 =
-  let give_up = OneArmReplaced { path = []; arm = p2 } in
+  let give_up = ArmReplaced { path = []; arm = p2 } in
   match List.compare_lengths ps1 ps2 with
   | 0 ->
       (* Same length. Exactly one slot differing means we recurse on it
-         (the inner diff might be deep — an [OneArmAdded]/[OneArmRemoved]
+         (the inner diff might be deep — an [ArmAdded]/[ArmRemoved]
          whose path bubbles up via [prepend_path], or a leaf
-         [OneArmReplaced { path = [] }] which [prepend_path] turns into
+         [ArmReplaced { path = [] }] which [prepend_path] turns into
          [{ path = [i] }]). Anything else is a multi-arm give-up. *)
       begin match single_change ps1 ps2 with
       | Some (i, _) ->
@@ -181,7 +181,7 @@ and compare_children ~next:p2 ps1 ps2 =
                    in next" at the outer position, so bubbling it up with
                    [prepend_path] would mis-describe the edit. Demote to a
                    wholesale slot replacement. *)
-                OneArmReplaced { path = []; arm = child2 }
+                ArmReplaced { path = []; arm = child2 }
             | d -> d
           in
           prepend_path i inner
@@ -190,13 +190,13 @@ and compare_children ~next:p2 ps1 ps2 =
   | -1 ->
       (* ps1 shorter; an insertion into ps1 could make ps2. *)
       begin match single_insertion ps1 ps2 with
-      | Some (i, arm) -> OneArmAdded { path = [ i ]; arm }
+      | Some (i, arm) -> ArmAdded { path = [ i ]; arm }
       | None -> give_up
       end
   | 1 ->
       (* ps2 shorter; equivalently, an arm was removed from ps1. *)
       begin match single_insertion ps2 ps1 with
-      | Some (i, arm) -> OneArmRemoved { path = [ i ]; arm }
+      | Some (i, arm) -> ArmRemoved { path = [ i ]; arm }
       | None -> give_up
       end
   | _ -> failwith "Can't get here"
@@ -206,7 +206,7 @@ and compare_children ~next:p2 ps1 ps2 =
    both the policy list and the weight list. *)
 and compare_wfq_children ~next:p2 ps1 (ws1 : float list) ps2 (ws2 : float list)
     =
-  let give_up = OneArmReplaced { path = []; arm = p2 } in
+  let give_up = ArmReplaced { path = []; arm = p2 } in
   match List.compare_lengths ps1 ps2 with
   | 0 when ws1 = ws2 ->
       (* Pure policy edit in-place; weights unchanged. Defer to the
@@ -230,8 +230,8 @@ and compare_wfq_children ~next:p2 ps1 (ws1 : float list) ps2 (ws2 : float list)
       begin match single_change_lockstep ps1 ps2 ws1 ws2 with
       | Some (i, _, weight) ->
           begin match analyze (List.nth ps1 i) (List.nth ps2 i) with
-          | OneArmReplaced { path = []; arm } ->
-              OneArmReplacedWFQ { path = [ i ]; arm; weight }
+          | ArmReplaced { path = []; arm } ->
+              ArmReplacedWFQ { path = [ i ]; arm; weight }
           | _ -> give_up
           end
       | None -> give_up
@@ -239,14 +239,14 @@ and compare_wfq_children ~next:p2 ps1 (ws1 : float list) ps2 (ws2 : float list)
   | -1 ->
       (* ps1 shorter: a slot was added to make ps2, with its weight. *)
       begin match single_insertion_lockstep ps1 ps2 ws1 ws2 with
-      | Some (i, arm, weight) -> OneArmAddedWFQ { path = [ i ]; arm; weight }
+      | Some (i, arm, weight) -> ArmAddedWFQ { path = [ i ]; arm; weight }
       | None -> give_up
       end
   | 1 ->
       (* ps2 shorter: a slot was removed from ps1. The dropped weight
-         isn't needed to describe the removal, so we use [OneArmRemoved]. *)
+         isn't needed to describe the removal, so we use [ArmRemoved]. *)
       begin match single_insertion_lockstep ps2 ps1 ws2 ws1 with
-      | Some (i, arm, _) -> OneArmRemoved { path = [ i ]; arm }
+      | Some (i, arm, _) -> ArmRemoved { path = [ i ]; arm }
       | None -> give_up
       end
   | _ -> failwith "Can't get here"
@@ -270,7 +270,7 @@ and analyze p1 p2 =
                position. The leaf-level diff is path-empty; [compare_lists]'s
                [prepend_path] tags on the child index when this bubbles up,
                but only if it's the sole divergence at that level. *)
-            OneArmReplaced { path = []; arm = p2 })
+            ArmReplaced { path = []; arm = p2 })
 
 (* Pretty-printers — only used to format failure messages from the test
    suite; the patcher never goes through these. *)
@@ -297,16 +297,13 @@ let string_of_weight_change { path; new_weight } =
 
 let to_string = function
   | Same -> "Same"
-  | OneArmAdded ad -> Printf.sprintf "OneArmAdded: %s" (string_of_arm_diff ad)
-  | OneArmAddedWFQ ad ->
-      Printf.sprintf "OneArmAddedWFQ: %s" (string_of_arm_diff_w ad)
-  | OneArmRemoved ad ->
-      Printf.sprintf "OneArmRemoved: %s" (string_of_arm_diff ad)
+  | ArmAdded ad -> Printf.sprintf "ArmAdded: %s" (string_of_arm_diff ad)
+  | ArmAddedWFQ ad -> Printf.sprintf "ArmAddedWFQ: %s" (string_of_arm_diff_w ad)
+  | ArmRemoved ad -> Printf.sprintf "ArmRemoved: %s" (string_of_arm_diff ad)
   | WeightChanged wc ->
       Printf.sprintf "WeightChanged: %s" (string_of_weight_change wc)
-  | OneArmReplaced ad ->
-      Printf.sprintf "OneArmReplaced: %s" (string_of_arm_diff ad)
-  | OneArmReplacedWFQ ad ->
-      Printf.sprintf "OneArmReplacedWFQ: %s" (string_of_arm_diff_w ad)
+  | ArmReplaced ad -> Printf.sprintf "ArmReplaced: %s" (string_of_arm_diff ad)
+  | ArmReplacedWFQ ad ->
+      Printf.sprintf "ArmReplacedWFQ: %s" (string_of_arm_diff_w ad)
   | SuperPol p -> Printf.sprintf "SuperPol at %s" (path_to_string p)
   | SubPol p -> Printf.sprintf "SubPol at %s" (path_to_string p)

--- a/rio/compare/compare.ml
+++ b/rio/compare/compare.ml
@@ -17,8 +17,16 @@ type t =
     (* WFQ-specific arm replacement: a single WFQ slot's arm and weight
        both changed. Bundles the new arm and the new weight together so
        it doesn't decompose into [OneArmReplaced] + [WeightChanged]. *)
-  | SuperPol of path (* [path] points to [prev] inside [next]. *)
-  | SubPol of path (* [path] points to [next] inside [prev]. *)
+  | SuperPol of path
+    (* [SuperPol]/[SubPol] are only emitted at the top level of [analyze]:
+       [SuperPol path] means [path] points to [prev] inside [next];
+       [SubPol path] means [path] points to [next] inside [prev]. When
+       nested comparisons would otherwise bubble one of these up through
+       [compare_children], we demote to [OneArmReplaced] at the differing
+       slot — the inner sub-policy path would no longer describe "prev
+       sits inside next" (or vice versa), just "child1 sits inside
+       child2", which is not actionable from [Ir.patch]. *)
+  | SubPol of path
 
 and arm_diff = {
   path : path;
@@ -163,7 +171,20 @@ and compare_children ~next:p2 ps1 ps2 =
          [{ path = [i] }]). Anything else is a multi-arm give-up. *)
       begin match single_change ps1 ps2 with
       | Some (i, _) ->
-          prepend_path i (analyze (List.nth ps1 i) (List.nth ps2 i))
+          let child1 = List.nth ps1 i in
+          let child2 = List.nth ps2 i in
+          let inner =
+            match analyze child1 child2 with
+            | SuperPol _ | SubPol _ ->
+                (* A nested [SuperPol]/[SubPol] only says "child1 embeds in
+                   child2" (or vice versa) — it does NOT say "prev embeds
+                   in next" at the outer position, so bubbling it up with
+                   [prepend_path] would mis-describe the edit. Demote to a
+                   wholesale slot replacement. *)
+                OneArmReplaced { path = []; arm = child2 }
+            | d -> d
+          in
+          prepend_path i inner
       | None -> if ps1 = ps2 then Same else give_up
       end
   | -1 ->

--- a/rio/ir/decorated.ml
+++ b/rio/ir/decorated.ml
@@ -170,7 +170,7 @@ let set_weight k new_w = function
   | _ -> failwith "Decorated.set_weight: WFQ-only"
 
 (* Replace child at index [k], preserving the parent→child step (and WFQ
-   weight). Used by [OneArmReplaced]: the new arm rides on the existing
+   weight). Used by [ArmReplaced]: the new arm rides on the existing
    [step_k], with the old root [Designate]d as the new root's predecessor. *)
 let replace_arm k new_child = function
   | FIFO _ -> failwith "Decorated.replace_arm: FIFO"

--- a/rio/ir/ir.ml
+++ b/rio/ir/ir.ml
@@ -497,17 +497,16 @@ let patch ~prev ~(next : Rio_core.Policy.t) : compiled option =
   let open Rio_compare.Compare in
   match analyze (Decorated.to_policy prev.decorated) next with
   | Same -> Some { prog = []; decorated = prev.decorated; pes = prev.pes }
-  | OneArmReplaced { path = []; _ } -> patch_whole_tree_replace ~prev ~next
-  | OneArmReplaced { path; arm } ->
+  | ArmReplaced { path = []; _ } -> patch_whole_tree_replace ~prev ~next
+  | ArmReplaced { path; arm } ->
       patch_one_arm_replaced ~prev ~arm_path:path ~arm ~wfq_weight:None
-  | OneArmReplacedWFQ { path; arm; weight } ->
+  | ArmReplacedWFQ { path; arm; weight } ->
       patch_one_arm_replaced ~prev ~arm_path:path ~arm ~wfq_weight:(Some weight)
-  | OneArmAdded { path; arm } ->
+  | ArmAdded { path; arm } ->
       patch_one_arm_added ~prev ~arm_path:path ~arm ~wfq_weight:None
-  | OneArmAddedWFQ { path; arm; weight } ->
+  | ArmAddedWFQ { path; arm; weight } ->
       patch_one_arm_added ~prev ~arm_path:path ~arm ~wfq_weight:(Some weight)
-  | OneArmRemoved { path; arm = _ } ->
-      patch_one_arm_removed ~prev ~arm_path:path
+  | ArmRemoved { path; arm = _ } -> patch_one_arm_removed ~prev ~arm_path:path
   | WeightChanged { path; new_weight } ->
       patch_weight_changed ~prev ~path ~new_weight
   | SuperPol [] | SubPol [] -> None

--- a/rio/ir/ir.mli
+++ b/rio/ir/ir.mli
@@ -54,7 +54,7 @@ val patch : prev:compiled -> next:Rio_core.Policy.t -> compiled option
     - [next] is structurally equal to [prev]'s policy: returns [Some] with an
       empty [prog].
     - [next] adds exactly one arm at any position of a [UNION], [RR], or [SP]
-      parent (per [OneArmAdded]): returns [Some] with the
+      parent (per [ArmAdded]): returns [Some] with the
       [Spawn]/[Adopt]/[Assoc]/[Map]/[Change_pol] (and [Change_weight] for [SP],
       both for the new arm and for any existing arms whose positional priority
       shifts) instructions needed to splice the new arm in.
@@ -62,13 +62,12 @@ val patch : prev:compiled -> next:Rio_core.Policy.t -> compiled option
       [WeightChanged]): returns [Some] with a single [Change_weight] instruction
       for the affected slot.
     - [next] removes exactly one arm at any position of a [UNION], [RR], or [SP]
-      parent (per [OneArmRemoved]): returns [Some] with the [Change_weight]
-      (only for [SP] siblings whose positional priority shifts down),
-      [Change_pol], [Unmap], [Deassoc], [Emancipate], and [GC] instructions
-      needed to detach the arm and clean up routing state cached on its ancestor
-      chain.
+      parent (per [ArmRemoved]): returns [Some] with the [Change_weight] (only
+      for [SP] siblings whose positional priority shifts down), [Change_pol],
+      [Unmap], [Deassoc], [Emancipate], and [GC] instructions needed to detach
+      the arm and clean up routing state cached on its ancestor chain.
     - [next] swaps in a different subtree at exactly one position (per
-      [OneArmReplaced]): returns [Some] with the new arm's
+      [ArmReplaced]): returns [Some] with the new arm's
       [Spawn]/[Adopt]/[Assoc]/[Map]/[Change_pol]/[Change_weight] instructions, a
       [Designate] that fuses the old and new roots into a super-node riding on
       the existing parent step, [Deassoc]s that drain the old classes out of the

--- a/rio/tests/frontend/test_compare.ml
+++ b/rio/tests/frontend/test_compare.ml
@@ -150,6 +150,30 @@ let one_arm_replaced_wfq =
       (OneArmReplacedWFQ { path = [ 2 ]; arm = Policy.FIFO "Z"; weight = 7.0 });
   ]
 
+(* Nested-recursion regression tests for #112. When [compare_children]
+   recurses into a single differing slot and the child's [analyze] returns
+   [SuperPol]/[SubPol], the path inside that variant only describes the
+   inner embedding (child1 inside child2 or vice versa) — NOT the
+   whole-prev embedding the variant documents at the top level. We demote
+   such results to [OneArmReplaced] at the slot, so [Ir.patch] can act on
+   them. *)
+let nested_superpol_subpol_demotion =
+  [
+    (* SP(A, B) vs SP(A, rr[B, C]): at the differing slot 1, the inner
+       analyze(B, rr[B, C]) yields SuperPol [0]. Pre-fix, this bubbled up
+       as SuperPol [1; 0], whose path does not point to prev inside next.
+       Now demoted to OneArmReplaced { path = [1]; arm = rr[B, C] }. *)
+    make_compare_test "nested SuperPol demotes to OneArmReplaced" "strict_AB"
+      "strict_A_rrBC"
+      (OneArmReplaced
+         { path = [ 1 ]; arm = Policy.RR [ Policy.FIFO "B"; Policy.FIFO "C" ] });
+    (* Inverse: SP(A, rr[B, C]) vs SP(A, B). Inner analyze yields SubPol [0];
+       demoted to OneArmReplaced { path = [1]; arm = B }. *)
+    make_compare_test "nested SubPol demotes to OneArmReplaced" "strict_A_rrBC"
+      "strict_AB"
+      (OneArmReplaced { path = [ 1 ]; arm = Policy.FIFO "B" });
+  ]
+
 let superpol =
   [
     make_compare_test "fifo_G is sub-pol of union[G,H]" "fifo_G" "union_GH"
@@ -229,6 +253,6 @@ let suite =
   "compare tests"
   >::: same @ one_arm_added @ one_arm_added_wfq @ armsremoved @ weightchanged
        @ onearmreplaced @ one_arm_replaced_wfq @ verydiff_combos @ superpol
-       @ subpol
+       @ subpol @ nested_superpol_subpol_demotion
 
 let () = run_test_tt_main suite

--- a/rio/tests/frontend/test_compare.ml
+++ b/rio/tests/frontend/test_compare.ml
@@ -152,43 +152,13 @@ let one_arm_replaced_wfq =
 
 let nested_superpol_subpol_demotion =
   [
-    (* SP(A, B) vs SP(A, rr[B, C]): at the differing slot 1, the inner
-       analyze(B, rr[B, C]) yields SuperPol [0]. Pre-fix, this bubbled up
-       as SuperPol [1; 0], whose path does not point to prev inside next.
-       Now demoted to ArmReplaced { path = [1]; arm = rr[B, C] }. *)
     make_compare_test "nested SuperPol demotes to ArmReplaced" "strict_AB"
       "strict_A_rrBC"
       (ArmReplaced
          { path = [ 1 ]; arm = Policy.RR [ Policy.FIFO "B"; Policy.FIFO "C" ] });
-    (* Inverse: SP(A, rr[B, C]) vs SP(A, B). Inner analyze yields SubPol [0];
-       demoted to ArmReplaced { path = [1]; arm = B }. *)
     make_compare_test "nested SubPol demotes to ArmReplaced" "strict_A_rrBC"
       "strict_AB"
       (ArmReplaced { path = [ 1 ]; arm = Policy.FIFO "B" });
-  ]
-
-(* Nested-recursion regression tests for #112. When [compare_children]
-   recurses into a single differing slot and the child's [analyze] returns
-   [SuperPol]/[SubPol], the path inside that variant only describes the
-   inner embedding (child1 inside child2 or vice versa) — NOT the
-   whole-prev embedding the variant documents at the top level. We demote
-   such results to [OneArmReplaced] at the slot, so [Ir.patch] can act on
-   them. *)
-let nested_superpol_subpol_demotion =
-  [
-    (* SP(A, B) vs SP(A, rr[B, C]): at the differing slot 1, the inner
-       analyze(B, rr[B, C]) yields SuperPol [0]. Pre-fix, this bubbled up
-       as SuperPol [1; 0], whose path does not point to prev inside next.
-       Now demoted to OneArmReplaced { path = [1]; arm = rr[B, C] }. *)
-    make_compare_test "nested SuperPol demotes to OneArmReplaced" "strict_AB"
-      "strict_A_rrBC"
-      (OneArmReplaced
-         { path = [ 1 ]; arm = Policy.RR [ Policy.FIFO "B"; Policy.FIFO "C" ] });
-    (* Inverse: SP(A, rr[B, C]) vs SP(A, B). Inner analyze yields SubPol [0];
-       demoted to OneArmReplaced { path = [1]; arm = B }. *)
-    make_compare_test "nested SubPol demotes to OneArmReplaced" "strict_A_rrBC"
-      "strict_AB"
-      (OneArmReplaced { path = [ 1 ]; arm = Policy.FIFO "B" });
   ]
 
 let superpol =

--- a/rio/tests/frontend/test_compare.ml
+++ b/rio/tests/frontend/test_compare.ml
@@ -19,12 +19,12 @@ let make_compare_test name file1 file2 expected_diff =
 
 (* Helper for the "give up" cases below: [Compare] couldn't break the
    diff down at depth [List.length path], so it emits
-   [OneArmReplaced { path; arm = walk policy2 path }] — the IR-side
+   [ArmReplaced { path; arm = walk policy2 path }] — the IR-side
    instruction is "wholesale replace this subtree with next's." *)
 let make_giveup_test name file1 file2 path =
   let policy2 = prog_to_policy file2 in
   let arm = Policy.walk policy2 path in
-  make_compare_test name file1 file2 (OneArmReplaced { path; arm })
+  make_compare_test name file1 file2 (ArmReplaced { path; arm })
 
 let same =
   [
@@ -33,44 +33,44 @@ let same =
     make_compare_test "merely jumbled in WFQ" "wfq_ABC" "wfq_ABC_jumbled" Same;
   ]
 
-(* OneArmAdded fires on a single-arm insertion at any position of a
+(* ArmAdded fires on a single-arm insertion at any position of a
    UNION/RR/SP parent (after [Policy.normalize] has sorted UNION/RR
-   children). WFQ-add lands in the dedicated [OneArmAddedWFQ] variant
+   children). WFQ-add lands in the dedicated [ArmAddedWFQ] variant
    (see [one_arm_added_wfq]) since the new slot also carries a weight.
    Multi-arm insertions instead "give up" to a wholesale-replace
-   [OneArmReplaced] (see [verydiff_combos]). The
+   [ArmReplaced] (see [verydiff_combos]). The
    [path] inside [arm_diff] is the new arm's full position from the
    root of [next]. *)
 let one_arm_added =
   [
     (* SP(A,B) vs SP(A,B,C) — append; new arm at root child 2. *)
     make_compare_test "strict arm added at end" "strict_AB" "strict_ABC"
-      (OneArmAdded { path = [ 2 ]; arm = Policy.FIFO "C" });
+      (ArmAdded { path = [ 2 ]; arm = Policy.FIFO "C" });
     (* SP(A,C) vs SP(A,B,C) — mid-insert; new arm at root child 1. *)
     make_compare_test "strict arm added in the middle" "strict_AC" "strict_ABC"
-      (OneArmAdded { path = [ 1 ]; arm = Policy.FIFO "B" });
+      (ArmAdded { path = [ 1 ]; arm = Policy.FIFO "B" });
     (* RR(A,B) vs RR(A,B,C) — append. *)
     make_compare_test "RR with arm added at end" "rr_AB" "rr_ABC"
-      (OneArmAdded { path = [ 2 ]; arm = Policy.FIFO "C" });
+      (ArmAdded { path = [ 2 ]; arm = Policy.FIFO "C" });
     (* RR(A,B) vs RR(B,A,C) — both sort to [A,B,...], so still an append. *)
     make_compare_test "RR with arm added whilst reordering" "rr_AB" "rr_BAC"
-      (OneArmAdded { path = [ 2 ]; arm = Policy.FIFO "C" });
+      (ArmAdded { path = [ 2 ]; arm = Policy.FIFO "C" });
     (* Adding an arm deep inside a tree with WFQ at root. The root WFQ
        is a transparent passthrough (lengths and weights line up), so
        the diff surfaces at the rr child (path [1]); the new D inside
        that RR sits at child index 2, giving a full path of [1; 2]. *)
     make_compare_test "WFQ with arm added deep" "wfq_complex"
       "wfq_complex_add_arm_deep"
-      (OneArmAdded { path = [ 1; 2 ]; arm = Policy.FIFO "D" });
+      (ArmAdded { path = [ 1; 2 ]; arm = Policy.FIFO "D" });
     (* Adding an arm deep inside the complex tree. After normalize, the
        WFQ pairs sort to (UNION, SP, RR), so the rr arm is at index 2;
        the new NEW inside that RR sits at child index 3 → [2; 3]. *)
     make_compare_test "complex tree add arm deep" "complex_tree"
       "complex_tree_add_arm_deep"
-      (OneArmAdded { path = [ 2; 3 ]; arm = Policy.FIFO "NEW" });
+      (ArmAdded { path = [ 2; 3 ]; arm = Policy.FIFO "NEW" });
   ]
 
-(* OneArmAddedWFQ: a WFQ parent gains exactly one slot. Detected when the
+(* ArmAddedWFQ: a WFQ parent gains exactly one slot. Detected when the
    policy list and the weight list each show a single insertion at the
    same index. The carried [weight] is the new slot's weight in [next]. *)
 let one_arm_added_wfq =
@@ -79,7 +79,7 @@ let one_arm_added_wfq =
        [(A,2),(B,1)] and next to [(A,2),(B,1),(C,3)]. The C slot is the
        lone insertion (index 2, weight 3). *)
     make_compare_test "WFQ with arm added at end" "wfq_BA" "wfq_ABC"
-      (OneArmAddedWFQ { path = [ 2 ]; arm = Policy.FIFO "C"; weight = 3.0 });
+      (ArmAddedWFQ { path = [ 2 ]; arm = Policy.FIFO "C"; weight = 3.0 });
     (* complex_tree_partial → complex_tree: at the root WFQ a new
        (rr[D,E,F], 2) slot appears. Children sort by variant tag
        (UNION < SP < RR), so prev pairs are [(UNION,3),(SP,1)] and next
@@ -87,7 +87,7 @@ let one_arm_added_wfq =
        weight 2. *)
     make_compare_test "complex tree fill in missing arm" "complex_tree_partial"
       "complex_tree"
-      (OneArmAddedWFQ
+      (ArmAddedWFQ
          {
            path = [ 2 ];
            arm = Policy.RR [ Policy.FIFO "D"; Policy.FIFO "E"; Policy.FIFO "F" ];
@@ -99,17 +99,17 @@ let armsremoved =
   [
     (* RR(A,B,C) -> RR(A,B): one arm dropped from the end. *)
     make_compare_test "RR with arm removed" "rr_ABC" "rr_AB"
-      (OneArmRemoved { path = [ 2 ]; arm = Policy.FIFO "C" });
+      (ArmRemoved { path = [ 2 ]; arm = Policy.FIFO "C" });
     (* WFQ(A:2,B:1,C:3) -> WFQ(B:1,A:2): post-normalize prev has C at
        index 2; that's what was removed. The IR can recover the dropped
        weight (3) from the prev decorated tree if it cares. *)
     make_compare_test "WFQ with arm removed" "wfq_ABC" "wfq_BA"
-      (OneArmRemoved { path = [ 2 ]; arm = Policy.FIFO "C" });
+      (ArmRemoved { path = [ 2 ]; arm = Policy.FIFO "C" });
     (* Inverse of the deep-add test: drop NEW from the inner RR (path [2]).
        NEW lived at index 3 inside that RR → full path [2; 3]. *)
     make_compare_test "complex tree remove arm deep" "complex_tree_add_arm_deep"
       "complex_tree"
-      (OneArmRemoved { path = [ 2; 3 ]; arm = Policy.FIFO "NEW" });
+      (ArmRemoved { path = [ 2; 3 ]; arm = Policy.FIFO "NEW" });
   ]
 
 let weightchanged =
@@ -125,53 +125,46 @@ let onearmreplaced =
   [
     (* SP(A,B) vs SP(A,C): exactly one arm differs (index 1). *)
     make_compare_test "strict arm changed" "strict_AB" "strict_AC"
-      (OneArmReplaced { path = [ 1 ]; arm = Policy.FIFO "C" });
+      (ArmReplaced { path = [ 1 ]; arm = Policy.FIFO "C" });
     (* RR(A,B) vs RR(A,D): exactly one arm differs (index 1). *)
     make_compare_test "rr arm changed" "rr_AB" "rr_AD"
-      (OneArmReplaced { path = [ 1 ]; arm = Policy.FIFO "D" });
+      (ArmReplaced { path = [ 1 ]; arm = Policy.FIFO "D" });
     (* WFQ(A:2,B:1,C:3) vs WFQ(A:2,B:1,Z:3): one slot's arm changed in
        place, weight unchanged. The IR recovers the slot's weight from
        the prev decorated tree. *)
     make_compare_test "WFQ arm changed in place, same weight" "wfq_ABC"
       "wfq_ABZ"
-      (OneArmReplaced { path = [ 2 ]; arm = Policy.FIFO "Z" });
+      (ArmReplaced { path = [ 2 ]; arm = Policy.FIFO "Z" });
   ]
 
-(* OneArmReplacedWFQ: a single WFQ slot's arm and weight both changed.
+(* ArmReplacedWFQ: a single WFQ slot's arm and weight both changed.
    Detected when policy and weight lists each have exactly one
    in-place divergence at the same slot, and the slot's arm-vs-arm
-   diff itself is a leaf-level [OneArmReplaced]. *)
+   diff itself is a leaf-level [ArmReplaced]. *)
 let one_arm_replaced_wfq =
   [
     (* WFQ(A:2,B:1,C:3) → WFQ(A:2,B:1,Z:7): slot 2's arm flipped C→Z and
        weight 3→7 in the same edit. *)
     make_compare_test "WFQ slot with arm change and weight change" "wfq_ABC"
       "wfq_ABZ_diff"
-      (OneArmReplacedWFQ { path = [ 2 ]; arm = Policy.FIFO "Z"; weight = 7.0 });
+      (ArmReplacedWFQ { path = [ 2 ]; arm = Policy.FIFO "Z"; weight = 7.0 });
   ]
 
-(* Nested-recursion regression tests for #112. When [compare_children]
-   recurses into a single differing slot and the child's [analyze] returns
-   [SuperPol]/[SubPol], the path inside that variant only describes the
-   inner embedding (child1 inside child2 or vice versa) — NOT the
-   whole-prev embedding the variant documents at the top level. We demote
-   such results to [OneArmReplaced] at the slot, so [Ir.patch] can act on
-   them. *)
 let nested_superpol_subpol_demotion =
   [
     (* SP(A, B) vs SP(A, rr[B, C]): at the differing slot 1, the inner
        analyze(B, rr[B, C]) yields SuperPol [0]. Pre-fix, this bubbled up
        as SuperPol [1; 0], whose path does not point to prev inside next.
-       Now demoted to OneArmReplaced { path = [1]; arm = rr[B, C] }. *)
-    make_compare_test "nested SuperPol demotes to OneArmReplaced" "strict_AB"
+       Now demoted to ArmReplaced { path = [1]; arm = rr[B, C] }. *)
+    make_compare_test "nested SuperPol demotes to ArmReplaced" "strict_AB"
       "strict_A_rrBC"
-      (OneArmReplaced
+      (ArmReplaced
          { path = [ 1 ]; arm = Policy.RR [ Policy.FIFO "B"; Policy.FIFO "C" ] });
     (* Inverse: SP(A, rr[B, C]) vs SP(A, B). Inner analyze yields SubPol [0];
-       demoted to OneArmReplaced { path = [1]; arm = B }. *)
-    make_compare_test "nested SubPol demotes to OneArmReplaced" "strict_A_rrBC"
+       demoted to ArmReplaced { path = [1]; arm = B }. *)
+    make_compare_test "nested SubPol demotes to ArmReplaced" "strict_A_rrBC"
       "strict_AB"
-      (OneArmReplaced { path = [ 1 ]; arm = Policy.FIFO "B" });
+      (ArmReplaced { path = [ 1 ]; arm = Policy.FIFO "B" });
   ]
 
 let superpol =
@@ -204,7 +197,7 @@ let subpol =
 
 (* A menu of cases where the diff is a *combination* of changes each of
    which would be legal in isolation, so [Compare] gives up at the level
-   of the divergence and emits [OneArmReplaced { path; arm = next_at_path }]
+   of the divergence and emits [ArmReplaced { path; arm = next_at_path }]
    — the IR will replace that subtree wholesale via [Designate]. As
    [Compare] gets smarter (e.g., learns to emit a list of edits), entries
    here will migrate to more precise variants. Each entry's comment names
@@ -212,29 +205,29 @@ let subpol =
 let verydiff_combos =
   [
     (* wfq_complex = WFQ([(A,1), (RR[B,C],2)]). Next changes RR[B,C]→RR[B,D]
-       (a deeper [OneArmReplaced]) and bumps the weight 2→5 (a
+       (a deeper [ArmReplaced]) and bumps the weight 2→5 (a
        [WeightChanged]) at the same slot. *)
     make_giveup_test "WFQ slot with deep diff and weight change" "wfq_complex"
       "wfq_complex_deep_and_weight" [];
     (* RR(A,B) → RR(D,B,A,SP(C,E)): two new arms (D and SP[C,E]) — a
-       multi-arm add, hence two [OneArmAdded]s. *)
+       multi-arm add, hence two [ArmAdded]s. *)
     make_giveup_test "RR with two arms added whilst reordering" "rr_AB"
       "rr_DBA_SP_CE" [];
-    (* SP(B,A) → SP(A,B,C): swap (= two [OneArmReplaced] at indices 0/1)
-       plus an [OneArmAdded] at index 2. *)
+    (* SP(B,A) → SP(A,B,C): swap (= two [ArmReplaced] at indices 0/1)
+       plus an [ArmAdded] at index 2. *)
     make_giveup_test "strict arm added whilst reordering arms" "strict_BA"
       "strict_ABC" [];
-    (* WFQ(A:1,B:2,C:3) → WFQ(D:1,E:2,F:3): three [OneArmReplaced]s, one
+    (* WFQ(A:1,B:2,C:3) → WFQ(D:1,E:2,F:3): three [ArmReplaced]s, one
        per slot. *)
     make_giveup_test "different WFQ classes" "wfq_ABC" "wfq_DEF" [];
-    (* RR(A,B) → RR(D,E,F): two [OneArmRemoved] (A and B drop) plus three
-       [OneArmAdded] (D, E, F appear). *)
+    (* RR(A,B) → RR(D,E,F): two [ArmRemoved] (A and B drop) plus three
+       [ArmAdded] (D, E, F appear). *)
     make_giveup_test "RR big diff" "rr_AB" "rr_DEF" [];
-    (* WFQ(B,A) → WFQ(A:2,B:2,C:4): one [OneArmAdded] (C) plus multiple
+    (* WFQ(B,A) → WFQ(A:2,B:2,C:4): one [ArmAdded] (C) plus multiple
        [WeightChanged]s on the existing arms. *)
     make_giveup_test "WFQ with weights changed and arm added" "wfq_BA"
       "wfq_ABC_diff" [];
-    (* SP(A,B) → SP(B,A): two [OneArmReplaced]s — both positions
+    (* SP(A,B) → SP(B,A): two [ArmReplaced]s — both positions
        diverge. *)
     make_giveup_test "Strict with arms reordered" "strict_AB" "strict_BA" [];
     (* Same swap one level deep inside complex_tree's SP[A;B;C]→SP[C;B;A].

--- a/rio/tests/ir/test_patch.ml
+++ b/rio/tests/ir/test_patch.ml
@@ -26,7 +26,7 @@ let make_delta_test name prev_file next_file (expected : program) =
   let c = patch_files prev_file next_file in
   assert_equal ~printer:Ir.string_of_program expected c.prog
 
-(* OneArmAdded *)
+(* ArmAdded *)
 
 (* There's a walkthrough for this case in the topmatter of the PR. *)
 let strict_ab_to_abc_expected : program =
@@ -96,7 +96,7 @@ let one_arm_added_tests =
       "complex_tree_add_arm_deep" complex_tree_add_deep_expected;
   ]
 
-(* OneArmAddedWFQ *)
+(* ArmAddedWFQ *)
 
 (* wfq_BA compiles with vpifos 100 (root WFQ), 101 (A), 102 (B); steps 1000
    (A), 1001 (B). Adding FIFO C at slot 2 with weight 3 mints v=103 (PE 1)
@@ -176,7 +176,7 @@ let weight_changed_tests =
       wfq_abc_to_one_weight_expected;
   ]
 
-(* OneArmRemoved *)
+(* ArmRemoved *)
 
 (* SP[A,B,C] -> SP[A,B]: drop C (last, index 2). No SP weight shifts. *)
 let strict_abc_to_ab_expected : program =
@@ -220,7 +220,7 @@ let one_arm_removed_tests =
       rr_abc_to_ab_expected;
   ]
 
-(* OneArmReplaced *)
+(* ArmReplaced *)
 
 (* RR[A,B] -> RR[A,D]: replace B (vpifo 102, step 1001) with FIFO D. The
    new arm rides on step 1001; B's super-node is set up via Designate(102,
@@ -259,7 +259,7 @@ let one_arm_replaced_tests =
       strict_ab_to_ac_expected;
   ]
 
-(* OneArmReplacedWFQ. wfq_ABC has root WFQ v=100 with leaves v=101/102/103
+(* ArmReplacedWFQ. wfq_ABC has root WFQ v=100 with leaves v=101/102/103
    for A/B/C on steps 1000/1001/1002. Replacing slot 2's arm (C → FIFO Z)
    *and* its weight (3 → 7) reuses step 1002: the new FIFO Z spawns on
    v=104 (PE 1), is [Designate]d onto v=103, ancestor routing on v=100
@@ -329,7 +329,7 @@ let rr_ab_to_rr_def_expected : program =
   ]
 
 (* Whole-tree replacement via constructor mismatch at the root (Compare
-   returns [OneArmReplaced { path = []; arm = RR[A,B] }]). prev =
+   returns [ArmReplaced { path = []; arm = RR[A,B] }]). prev =
    sp[A,B] (vpifos 100/101/102, steps 1000/1001); next = rr[A,B] —
    same children, different root policy, so Compare can't ride the
    existing slots. Same handler as the [VeryDifferent []] case above:
@@ -480,7 +480,7 @@ let super_pol_tests =
       strict_abc_to_complex_tree_expected;
   ]
 
-(* pes-extension regressions: when a OneArmAdded or OneArmReplaced inserts
+(* pes-extension regressions: when a ArmAdded or ArmReplaced inserts
    an arm whose internal depth pushes the tree deeper than [prev.pes]
    covered, [pes_extended_to_depth] should grow [pes] with fresh PEs above
    the existing max — keeping the "same depth ⇒ same PE" invariant for
@@ -536,10 +536,10 @@ let pes_extension_tests = [ one_arm_added_extends_pes_test ]
 
 (* Deep give-up: complex_tree -> complex_tree_swap_sp_arms differs only
    inside the SP subtree at root child 1 (multi-arm reorder). Compare
-   gives up at that level and emits [OneArmReplaced { path = [1]; arm }];
-   IR's existing OneArmReplaced handler routes through [Designate] on the
+   gives up at that level and emits [ArmReplaced { path = [1]; arm }];
+   IR's existing ArmReplaced handler routes through [Designate] on the
    parent's existing step. Smoke-test that patch returns [Some] — the
-   exact instruction sequence is exercised by the precise OneArmReplaced
+   exact instruction sequence is exercised by the precise ArmReplaced
    tests at non-empty paths above. *)
 let deep_giveup_test =
   "complex_tree -> swap_sp_arms (deep give-up)" >:: fun _ ->

--- a/rio/tests/progs/work_conserving/strict_A_rrBC.sched
+++ b/rio/tests/progs/work_conserving/strict_A_rrBC.sched
@@ -1,0 +1,5 @@
+classes A, B, C;
+
+policy = strict[A, rr[B, C]];
+
+return policy


### PR DESCRIPTION
The ADT in `compare.ml` had arms called `OneArmAdded`, `OneArmReplaced`, etc, which was a little annoying. This little PR just tidies this up by dropping the `One`.