### PR TITLE
Resolving Code Divergences, Part 2

### DIFF
--- a/rio/ir/frag.ml
+++ b/rio/ir/frag.ml
@@ -5,7 +5,8 @@ type t = {
   adopts : instr list;
   assocs : instr list;
   maps : instr list;
-  change_pols : instr list;
+  set_policies : instr list;
+  change_arities : instr list;
   change_weights : instr list;
   root_v : vpifo;
   classes : clss list;
@@ -17,7 +18,8 @@ let empty ~root_v ~classes =
     adopts = [];
     assocs = [];
     maps = [];
-    change_pols = [];
+    set_policies = [];
+    change_arities = [];
     change_weights = [];
     root_v;
     classes;
@@ -25,7 +27,15 @@ let empty ~root_v ~classes =
 
 let to_commit (f : t) : commit =
   List.concat
-    [ f.spawns; f.adopts; f.assocs; f.maps; f.change_pols; f.change_weights ]
+    [
+      f.spawns;
+      f.adopts;
+      f.assocs;
+      f.maps;
+      f.set_policies;
+      f.change_arities;
+      f.change_weights;
+    ]
 
 let combine (local : t) (children : t list) : t =
   let collect proj = proj local @ List.concat_map proj children in
@@ -34,7 +44,8 @@ let combine (local : t) (children : t list) : t =
     adopts = collect (fun f -> f.adopts);
     assocs = collect (fun f -> f.assocs);
     maps = collect (fun f -> f.maps);
-    change_pols = collect (fun f -> f.change_pols);
+    set_policies = collect (fun f -> f.set_policies);
+    change_arities = collect (fun f -> f.change_arities);
     change_weights = collect (fun f -> f.change_weights);
     root_v = local.root_v;
     classes = local.classes;

--- a/rio/ir/frag.ml
+++ b/rio/ir/frag.ml
@@ -7,7 +7,7 @@ type t = {
   maps : instr list;
   set_policies : instr list;
   change_arities : instr list;
-  change_weights : instr list;
+  set_arm_metas : instr list;
   root_v : vpifo;
   classes : clss list;
 }
@@ -20,7 +20,7 @@ let empty ~root_v ~classes =
     maps = [];
     set_policies = [];
     change_arities = [];
-    change_weights = [];
+    set_arm_metas = [];
     root_v;
     classes;
   }
@@ -34,7 +34,7 @@ let to_commit (f : t) : commit =
       f.maps;
       f.set_policies;
       f.change_arities;
-      f.change_weights;
+      f.set_arm_metas;
     ]
 
 let combine (local : t) (children : t list) : t =
@@ -46,7 +46,7 @@ let combine (local : t) (children : t list) : t =
     maps = collect (fun f -> f.maps);
     set_policies = collect (fun f -> f.set_policies);
     change_arities = collect (fun f -> f.change_arities);
-    change_weights = collect (fun f -> f.change_weights);
+    set_arm_metas = collect (fun f -> f.set_arm_metas);
     root_v = local.root_v;
     classes = local.classes;
   }

--- a/rio/ir/frag.mli
+++ b/rio/ir/frag.mli
@@ -10,7 +10,8 @@ type t = {
   adopts : instr list;
   assocs : instr list;
   maps : instr list;
-  change_pols : instr list;
+  set_policies : instr list;
+  change_arities : instr list;
   change_weights : instr list;
   root_v : vpifo;
   classes : clss list;
@@ -20,8 +21,8 @@ val empty : root_v:vpifo -> classes:clss list -> t
 (** A frag carrying no instructions; just [root_v] and [classes]. *)
 
 val to_commit : t -> commit
-(** Flatten a frag's six instruction kinds in canonical order: spawns, adopts,
-    assocs, maps, change_pols, change_weights. *)
+(** Flatten a frag's seven instruction kinds in canonical order: spawns, adopts,
+    assocs, maps, set_policies, change_arities, change_weights. *)
 
 val combine : t -> t list -> t
 (** [combine local children] interleaves a parent's [local] frag with each of

--- a/rio/ir/frag.mli
+++ b/rio/ir/frag.mli
@@ -12,7 +12,7 @@ type t = {
   maps : instr list;
   set_policies : instr list;
   change_arities : instr list;
-  change_weights : instr list;
+  set_arm_metas : instr list;
   root_v : vpifo;
   classes : clss list;
 }
@@ -22,7 +22,7 @@ val empty : root_v:vpifo -> classes:clss list -> t
 
 val to_commit : t -> commit
 (** Flatten a frag's seven instruction kinds in canonical order: spawns, adopts,
-    assocs, maps, set_policies, change_arities, change_weights. *)
+    assocs, maps, set_policies, change_arities, set_arm_metas. *)
 
 val combine : t -> t list -> t
 (** [combine local children] interleaves a parent's [local] frag with each of

--- a/rio/ir/instr.ml
+++ b/rio/ir/instr.ml
@@ -22,7 +22,7 @@ type instr =
   | Unmap of vpifo * clss * step
   | Set_policy of vpifo * pol_ty * int
   | Change_arity of vpifo * int
-  | Change_weight of vpifo * step * float
+  | Set_arm_meta of vpifo * step * float
   | GC of vpifo
   | Designate of vpifo * vpifo
   | Undesignate of vpifo
@@ -61,8 +61,8 @@ let string_of_instr = function
         (string_of_pol_ty pt) n
   | Change_arity (v, n) ->
       Printf.sprintf "change_arity(%s, %d)" (string_of_vpifo v) n
-  | Change_weight (v, s, w) ->
-      Printf.sprintf "change_weight(%s, %s, %F)" (string_of_vpifo v)
+  | Set_arm_meta (v, s, w) ->
+      Printf.sprintf "set_arm_meta(%s, %s, %F)" (string_of_vpifo v)
         (string_of_step s) w
   | GC v -> Printf.sprintf "gc(%s)" (string_of_vpifo v)
   | Designate (v, survivor) ->

--- a/rio/ir/instr.ml
+++ b/rio/ir/instr.ml
@@ -20,7 +20,8 @@ type instr =
   | Deassoc of vpifo * clss
   | Map of vpifo * clss * step
   | Unmap of vpifo * clss * step
-  | Change_pol of vpifo * pol_ty * int
+  | Set_policy of vpifo * pol_ty * int
+  | Change_arity of vpifo * int
   | Change_weight of vpifo * step * float
   | GC of vpifo
   | Designate of vpifo * vpifo
@@ -54,9 +55,11 @@ let string_of_instr = function
   | Unmap (v, c, s) ->
       Printf.sprintf "unmap(%s, %s, %s)" (string_of_vpifo v) c
         (string_of_step s)
-  | Change_pol (v, pt, n) ->
-      Printf.sprintf "change_pol(%s, %s, %d)" (string_of_vpifo v)
+  | Set_policy (v, pt, n) ->
+      Printf.sprintf "set_policy(%s, %s, %d)" (string_of_vpifo v)
         (string_of_pol_ty pt) n
+  | Change_arity (v, n) ->
+      Printf.sprintf "change_arity(%s, %d)" (string_of_vpifo v) n
   | Change_weight (v, s, w) ->
       Printf.sprintf "change_weight(%s, %s, %F)" (string_of_vpifo v)
         (string_of_step s) w

--- a/rio/ir/instr.ml
+++ b/rio/ir/instr.ml
@@ -25,6 +25,7 @@ type instr =
   | Change_weight of vpifo * step * float
   | GC of vpifo
   | Designate of vpifo * vpifo
+  | Undesignate of vpifo
 
 type commit = instr list
 
@@ -67,5 +68,6 @@ let string_of_instr = function
   | Designate (v, survivor) ->
       Printf.sprintf "designate(%s, %s)" (string_of_vpifo v)
         (string_of_vpifo survivor)
+  | Undesignate v -> Printf.sprintf "undesignate(%s)" (string_of_vpifo v)
 
 let string_of_commit p = p |> List.map string_of_instr |> String.concat "\n"

--- a/rio/ir/instr.mli
+++ b/rio/ir/instr.mli
@@ -52,6 +52,11 @@ type instr =
           arriving at [v] continues to flow through [v]; once [v] underflows and
           is collected (per a prior [GC]), the super-node collapses to
           [survivor]. Chains across multiple [Designate]s are allowed. *)
+  | Undesignate of vpifo
+      (** [Undesignate v]: collapse the super-node headed by [v] (with [v] ->
+          survivor) by rewiring the parent's index away from [v] and onto its
+          survivor. [v] itself stays allocated; a paired [GC v] in the same
+          commit releases its PE slot. *)
 
 type commit = instr list
 

--- a/rio/ir/instr.mli
+++ b/rio/ir/instr.mli
@@ -40,9 +40,11 @@ type instr =
       (** [Change_arity (v, n)]: set the live [v]'s arity to [n]. Shrinking
           drops rightmost slots; growing appends fresh ones. The policy type is
           unchanged. *)
-  | Change_weight of vpifo * step * float
-      (** [Change_weight (v, s, w)]: the child reached via step [s] has weight
-          [w]. *)
+  | Set_arm_meta of vpifo * step * float
+      (** [Set_arm_meta (v, s, w)]: set the per-arm metadata on the child
+          reached via step [s]. Today the payload is a single weight [w]; a
+          later refactor will reinterpret [w] per [v]'s policy type (a weight
+          for RR/WFQ; a priority rank for Strict). *)
   | GC of vpifo
       (** [GC v]: tell the garbage collector that [v] is available for
           collection. *)

--- a/rio/ir/instr.mli
+++ b/rio/ir/instr.mli
@@ -30,8 +30,16 @@ type instr =
   | Unmap of vpifo * clss * step
       (** [Unmap (v, c, s)]: inverse of [Map]. Forget [v]'s mapping from class
           [c] to step [s]. *)
-  | Change_pol of vpifo * pol_ty * int
-      (** [Change_pol (v, pol, n)]: set [v]'s policy to [pol] with [n] arms. *)
+  | Set_policy of vpifo * pol_ty * int
+      (** [Set_policy (v, pol, n)]: at lPIFO birth, fix [v]'s policy type to
+          [pol] and its initial arity to [n]. Issued exactly once per lPIFO at
+          spawn time; the paper fixes the policy type at lPIFO birth and the
+          initial arity is determined at the same moment, so the two facts ride
+          on a single opcode. Later arity changes use [Change_arity]. *)
+  | Change_arity of vpifo * int
+      (** [Change_arity (v, n)]: set the live [v]'s arity to [n]. Shrinking
+          drops rightmost slots; growing appends fresh ones. The policy type is
+          unchanged. *)
   | Change_weight of vpifo * step * float
       (** [Change_weight (v, s, w)]: the child reached via step [s] has weight
           [w]. *)

--- a/rio/ir/ir.ml
+++ b/rio/ir/ir.ml
@@ -250,6 +250,7 @@ let replace_at ~prev ~chain ~removed ~arm_depth ~arm ~rewrite_decorated =
         chain_emit (fun v _ c -> Deassoc (v, c)) chain only_removed;
         chain_emit (fun v _ c -> Assoc (v, c)) chain only_added;
         chain_emit (fun v s c -> Map (v, c, s)) chain only_added;
+        [ Undesignate removed_v ];
         gc_subtree removed;
       ]
   in

--- a/rio/ir/ir.ml
+++ b/rio/ir/ir.ml
@@ -444,11 +444,19 @@ let patch_super_pol ~prev ~next ~path =
       ~splice:(path, prev.decorated) next
   in
   let old_real_root_v = Decorated.root_vpifo prev.decorated in
+  let prev_classes = Decorated.subtree_classes prev.decorated in
+  let only_added =
+    List.filter
+      (fun c -> not (List.mem c prev_classes))
+      (Decorated.subtree_classes decorated)
+  in
   let rewire =
     [
       Emancipate (fake_root_step, fake_root_v, old_real_root_v);
       Adopt (fake_root_step, fake_root_v, frag.root_v);
     ]
+    @ chain_emit (fun v _ c -> Assoc (v, c)) fake_chain only_added
+    @ chain_emit (fun v s c -> Map (v, c, s)) fake_chain only_added
   in
   { commit = Frag.to_commit frag @ rewire; decorated; pes = new_pes }
 

--- a/rio/ir/ir.ml
+++ b/rio/ir/ir.ml
@@ -139,10 +139,10 @@ and compile_arm ~fresh_v ~fresh_s ~pe_of_depth ~depth ~pol_ty ~weights ?splice
              child_steps child_frags);
       set_policies = [ Set_policy (v, pol_ty, List.length children) ];
       change_arities = [];
-      change_weights =
+      set_arm_metas =
         (match weights with
         | [] -> []
-        | ws -> List.map2 (fun s w -> Change_weight (v, s, w)) child_steps ws);
+        | ws -> List.map2 (fun s w -> Set_arm_meta (v, s, w)) child_steps ws);
       root_v = v;
       classes = all_classes;
     }
@@ -167,7 +167,7 @@ let of_policy (p : Rio_core.Policy.t) : compiled =
         List.map (fun c -> Map (fake_root_v, c, fake_root_step)) frag.classes;
       set_policies = [ Set_policy (fake_root_v, UNION, 1) ];
       change_arities = [];
-      change_weights = [];
+      set_arm_metas = [];
       root_v = fake_root_v;
       classes = frag.classes;
     }
@@ -265,7 +265,7 @@ let patch_one_arm_replaced ~prev ~arm_path ~arm ~wfq_weight =
     | Some w ->
         let parent_v = Decorated.root_vpifo parent in
         let step_k = Decorated.nth_step parent k in
-        ([ Change_weight (parent_v, step_k, w) ], Decorated.set_weight k w)
+        ([ Set_arm_meta (parent_v, step_k, w) ], Decorated.set_weight k w)
   in
   let c =
     replace_at ~prev ~chain:(Decorated.ancestor_chain prev.decorated arm_path)
@@ -298,7 +298,7 @@ let patch_weight_changed ~prev ~path ~new_weight =
       (Decorated.set_weight k new_weight)
   in
   {
-    commit = [ Change_weight (parent_v, step_k, new_weight) ];
+    commit = [ Set_arm_meta (parent_v, step_k, new_weight) ];
     decorated = new_decorated;
     pes = prev.pes;
   }
@@ -319,16 +319,16 @@ let sp_inserted_weight_shifts ~parent_v ~parent ~k ~new_step =
   let shifted =
     List.filter_map
       (fun (j, (s, _)) ->
-        if j >= k then Some (Change_weight (parent_v, s, float_of_int (j + 2)))
+        if j >= k then Some (Set_arm_meta (parent_v, s, float_of_int (j + 2)))
         else None)
       (List.mapi (fun j e -> (j, e)) (sp_edges parent))
   in
-  Change_weight (parent_v, new_step, float_of_int (k + 1)) :: shifted
+  Set_arm_meta (parent_v, new_step, float_of_int (k + 1)) :: shifted
 
 let sp_removed_weight_shifts ~parent_v ~parent ~k =
   List.filter_map
     (fun (j, (s, _)) ->
-      if j > k then Some (Change_weight (parent_v, s, float_of_int j)) else None)
+      if j > k then Some (Set_arm_meta (parent_v, s, float_of_int j)) else None)
     (List.mapi (fun j e -> (j, e)) (sp_edges parent))
 
 (* Single-arm insertion under [parent]. *)
@@ -346,13 +346,13 @@ let patch_one_arm_added ~prev ~arm_path ~arm ~wfq_weight =
     compile_subtree ~fresh_v ~fresh_s ~pe_of_depth ~depth:arm_depth arm
   in
   let new_step = fresh_s () in
-  let change_weights, decorated_update =
+  let set_arm_metas, decorated_update =
     match (pol_ty, wfq_weight) with
     | SP, None ->
         ( sp_inserted_weight_shifts ~parent_v ~parent ~k ~new_step,
           Decorated.insert_arm k new_step arm_decorated )
     | WFQ, Some w ->
-        ( [ Change_weight (parent_v, new_step, w) ],
+        ( [ Set_arm_meta (parent_v, new_step, w) ],
           Decorated.insert_arm_wfq k new_step arm_decorated w )
     | (UNION | RR), None -> ([], Decorated.insert_arm k new_step arm_decorated)
     | _ ->
@@ -373,7 +373,7 @@ let patch_one_arm_added ~prev ~arm_path ~arm ~wfq_weight =
       maps = chain_emit (fun v s c -> Map (v, c, s)) chain arm_frag.classes;
       set_policies = [];
       change_arities = [ Change_arity (parent_v, old_arity + 1) ];
-      change_weights;
+      set_arm_metas;
       root_v = parent_v;
       classes = arm_frag.classes;
     }
@@ -394,7 +394,7 @@ let patch_one_arm_removed ~prev ~arm_path =
   let removed = Decorated.nth_child parent k in
   let removed_v = Decorated.root_vpifo removed in
   let step_k = Decorated.nth_step parent k in
-  let change_weights =
+  let set_arm_metas =
     match pol_ty with
     | SP -> sp_removed_weight_shifts ~parent_v ~parent ~k
     | _ -> []
@@ -404,7 +404,7 @@ let patch_one_arm_removed ~prev ~arm_path =
   let commit =
     List.concat
       [
-        change_weights;
+        set_arm_metas;
         [ Change_arity (parent_v, old_arity - 1) ];
         chain_emit (fun v s c -> Unmap (v, c, s)) chain removed_classes;
         chain_emit (fun v _ c -> Deassoc (v, c)) chain removed_classes;

--- a/rio/ir/ir.ml
+++ b/rio/ir/ir.ml
@@ -137,7 +137,8 @@ and compile_arm ~fresh_v ~fresh_s ~pe_of_depth ~depth ~pol_ty ~weights ?splice
              (fun s (cf : Frag.t) ->
                List.map (fun c -> Map (v, c, s)) cf.classes)
              child_steps child_frags);
-      change_pols = [ Change_pol (v, pol_ty, List.length children) ];
+      set_policies = [ Set_policy (v, pol_ty, List.length children) ];
+      change_arities = [];
       change_weights =
         (match weights with
         | [] -> []
@@ -164,7 +165,8 @@ let of_policy (p : Rio_core.Policy.t) : compiled =
       assocs = List.map (fun c -> Assoc (fake_root_v, c)) frag.classes;
       maps =
         List.map (fun c -> Map (fake_root_v, c, fake_root_step)) frag.classes;
-      change_pols = [ Change_pol (fake_root_v, UNION, 1) ];
+      set_policies = [ Set_policy (fake_root_v, UNION, 1) ];
+      change_arities = [];
       change_weights = [];
       root_v = fake_root_v;
       classes = frag.classes;
@@ -368,7 +370,8 @@ let patch_one_arm_added ~prev ~arm_path ~arm ~wfq_weight =
       adopts = [ Adopt (new_step, parent_v, arm_frag.root_v) ];
       assocs = chain_emit (fun v _ c -> Assoc (v, c)) chain arm_frag.classes;
       maps = chain_emit (fun v s c -> Map (v, c, s)) chain arm_frag.classes;
-      change_pols = [ Change_pol (parent_v, pol_ty, old_arity + 1) ];
+      set_policies = [];
+      change_arities = [ Change_arity (parent_v, old_arity + 1) ];
       change_weights;
       root_v = parent_v;
       classes = arm_frag.classes;
@@ -401,7 +404,7 @@ let patch_one_arm_removed ~prev ~arm_path =
     List.concat
       [
         change_weights;
-        [ Change_pol (parent_v, pol_ty, old_arity - 1) ];
+        [ Change_arity (parent_v, old_arity - 1) ];
         chain_emit (fun v s c -> Unmap (v, c, s)) chain removed_classes;
         chain_emit (fun v _ c -> Deassoc (v, c)) chain removed_classes;
         [ Emancipate (step_k, parent_v, removed_v) ];

--- a/rio/ir/ir.mli
+++ b/rio/ir/ir.mli
@@ -74,8 +74,9 @@ val patch : prev:compiled -> next:Rio_core.Policy.t -> compiled option
       [Designate] that fuses the old and new roots into a super-node riding on
       the existing parent step, [Deassoc]s that drain the old classes out of the
       displaced subtree and its ancestors, [Assoc]/[Map] entries that route the
-      new classes to the same step, and a [GC] per node of the displaced subtree
-      so they are collected once the displaced tree underflows.
+      new classes to the same step, an [Undesignate] paired with a [GC] on the
+      old root that collapses the super-node and releases its PE slot, and a
+      [GC] per remaining node of the displaced subtree.
     - [next] is structurally equal to a strict subtree of [prev] at a non-empty
       path (per [SubPol]): returns [Some] with an [Emancipate] detaching that
       subtree from its parent, a second [Emancipate]/[Adopt] pair on the fake

--- a/rio/ir/ir.mli
+++ b/rio/ir/ir.mli
@@ -55,22 +55,21 @@ val patch : prev:compiled -> next:Rio_core.Policy.t -> compiled option
       empty [commit].
     - [next] adds exactly one arm at any position of a [UNION], [RR], or [SP]
       parent (per [ArmAdded]): returns [Some] with the
-      [Spawn]/[Adopt]/[Assoc]/[Map]/[Change_arity] (and [Change_weight] for
-      [SP], both for the new arm and for any existing arms whose positional
-      priority shifts) instructions needed to splice the new arm in. The
-      parent's policy type is fixed at lPIFO birth, so no [Set_policy] is
-      emitted against it.
+      [Spawn]/[Adopt]/[Assoc]/[Map]/[Change_arity] (and [Set_arm_meta] for [SP],
+      both for the new arm and for any existing arms whose positional priority
+      shifts) instructions needed to splice the new arm in. The parent's policy
+      type is fixed at lPIFO birth, so no [Set_policy] is emitted against it.
     - [next] differs from [prev] only in the weight of one [WFQ] arm (per
-      [WeightChanged]): returns [Some] with a single [Change_weight] instruction
+      [WeightChanged]): returns [Some] with a single [Set_arm_meta] instruction
       for the affected slot.
     - [next] removes exactly one arm at any position of a [UNION], [RR], or [SP]
-      parent (per [ArmRemoved]): returns [Some] with the [Change_weight] (only
+      parent (per [ArmRemoved]): returns [Some] with the [Set_arm_meta] (only
       for [SP] siblings whose positional priority shifts down), [Change_arity],
       [Unmap], [Deassoc], [Emancipate], and [GC] instructions needed to detach
       the arm and clean up routing state cached on its ancestor chain.
     - [next] swaps in a different subtree at exactly one position (per
       [ArmReplaced]): returns [Some] with the new arm's
-      [Spawn]/[Adopt]/[Assoc]/[Map]/[Set_policy]/[Change_weight] instructions, a
+      [Spawn]/[Adopt]/[Assoc]/[Map]/[Set_policy]/[Set_arm_meta] instructions, a
       [Designate] that fuses the old and new roots into a super-node riding on
       the existing parent step, [Deassoc]s that drain the old classes out of the
       displaced subtree and its ancestors, [Assoc]/[Map] entries that route the
@@ -86,8 +85,8 @@ val patch : prev:compiled -> next:Rio_core.Policy.t -> compiled option
       is collected. The whole-tree case ([path = []]) returns [None].
     - [prev]'s policy appears as a strict subtree of [next] at a non-empty path
       (per [SuperPol]): returns [Some] with the
-      [Spawn]/[Adopt]/[Assoc]/[Map]/[Set_policy]/[Change_weight] instructions
-      for the new structure surrounding [prev], a single [Adopt] that grafts
+      [Spawn]/[Adopt]/[Assoc]/[Map]/[Set_policy]/[Set_arm_meta] instructions for
+      the new structure surrounding [prev], a single [Adopt] that grafts
       [prev]'s existing root in at the splice point, and an [Emancipate]/
       [Adopt] pair that repoints the fake root's single step from [prev]'s old
       real root to [next]'s new top. [prev]'s in-flight nodes are not respawned.

--- a/rio/ir/ir.mli
+++ b/rio/ir/ir.mli
@@ -55,20 +55,22 @@ val patch : prev:compiled -> next:Rio_core.Policy.t -> compiled option
       empty [commit].
     - [next] adds exactly one arm at any position of a [UNION], [RR], or [SP]
       parent (per [ArmAdded]): returns [Some] with the
-      [Spawn]/[Adopt]/[Assoc]/[Map]/[Change_pol] (and [Change_weight] for [SP],
-      both for the new arm and for any existing arms whose positional priority
-      shifts) instructions needed to splice the new arm in.
+      [Spawn]/[Adopt]/[Assoc]/[Map]/[Change_arity] (and [Change_weight] for
+      [SP], both for the new arm and for any existing arms whose positional
+      priority shifts) instructions needed to splice the new arm in. The
+      parent's policy type is fixed at lPIFO birth, so no [Set_policy] is
+      emitted against it.
     - [next] differs from [prev] only in the weight of one [WFQ] arm (per
       [WeightChanged]): returns [Some] with a single [Change_weight] instruction
       for the affected slot.
     - [next] removes exactly one arm at any position of a [UNION], [RR], or [SP]
       parent (per [ArmRemoved]): returns [Some] with the [Change_weight] (only
-      for [SP] siblings whose positional priority shifts down), [Change_pol],
+      for [SP] siblings whose positional priority shifts down), [Change_arity],
       [Unmap], [Deassoc], [Emancipate], and [GC] instructions needed to detach
       the arm and clean up routing state cached on its ancestor chain.
     - [next] swaps in a different subtree at exactly one position (per
       [ArmReplaced]): returns [Some] with the new arm's
-      [Spawn]/[Adopt]/[Assoc]/[Map]/[Change_pol]/[Change_weight] instructions, a
+      [Spawn]/[Adopt]/[Assoc]/[Map]/[Set_policy]/[Change_weight] instructions, a
       [Designate] that fuses the old and new roots into a super-node riding on
       the existing parent step, [Deassoc]s that drain the old classes out of the
       displaced subtree and its ancestors, [Assoc]/[Map] entries that route the
@@ -83,7 +85,7 @@ val patch : prev:compiled -> next:Rio_core.Policy.t -> compiled option
       is collected. The whole-tree case ([path = []]) returns [None].
     - [prev]'s policy appears as a strict subtree of [next] at a non-empty path
       (per [SuperPol]): returns [Some] with the
-      [Spawn]/[Adopt]/[Assoc]/[Map]/[Change_pol]/[Change_weight] instructions
+      [Spawn]/[Adopt]/[Assoc]/[Map]/[Set_policy]/[Change_weight] instructions
       for the new structure surrounding [prev], a single [Adopt] that grafts
       [prev]'s existing root in at the splice point, and an [Emancipate]/
       [Adopt] pair that repoints the fake root's single step from [prev]'s old

--- a/rio/ir/json.ml
+++ b/rio/ir/json.ml
@@ -53,10 +53,10 @@ let from_instr (i : Instr.instr) : Yojson.Basic.t =
         ]
   | Instr.Change_arity (v, n) ->
       `Assoc [ ("op", `String "change_arity"); ("v", `Int v); ("n", `Int n) ]
-  | Instr.Change_weight (v, s, w) ->
+  | Instr.Set_arm_meta (v, s, w) ->
       `Assoc
         [
-          ("op", `String "change_weight");
+          ("op", `String "set_arm_meta");
           ("v", `Int v);
           ("step", `Int s);
           ("weight", `Float w);

--- a/rio/ir/json.ml
+++ b/rio/ir/json.ml
@@ -67,6 +67,8 @@ let from_instr (i : Instr.instr) : Yojson.Basic.t =
         [
           ("op", `String "designate"); ("v", `Int v); ("survivor", `Int survivor);
         ]
+  | Instr.Undesignate v ->
+      `Assoc [ ("op", `String "undesignate"); ("v", `Int v) ]
 
 let from_commit (p : Instr.commit) : Yojson.Basic.t =
   `List [ `List (List.map from_instr p) ]

--- a/rio/ir/json.ml
+++ b/rio/ir/json.ml
@@ -43,14 +43,16 @@ let from_instr (i : Instr.instr) : Yojson.Basic.t =
           ("class", `String c);
           ("step", `Int s);
         ]
-  | Instr.Change_pol (v, pt, n) ->
+  | Instr.Set_policy (v, pt, n) ->
       `Assoc
         [
-          ("op", `String "change_pol");
+          ("op", `String "set_policy");
           ("v", `Int v);
           ("pol", from_pol_ty pt);
           ("n", `Int n);
         ]
+  | Instr.Change_arity (v, n) ->
+      `Assoc [ ("op", `String "change_arity"); ("v", `Int v); ("n", `Int n) ]
   | Instr.Change_weight (v, s, w) ->
       `Assoc
         [

--- a/rio/tests/ir/jsons/complex_tree.json
+++ b/rio/tests/ir/jsons/complex_tree.json
@@ -97,11 +97,11 @@
     { "op": "map", "v": 108, "class": "E", "step": 1006 },
     { "op": "map", "v": 108, "class": "F", "step": 1007 },
 
-    { "op": "change_pol", "v": 99, "pol": "UNION", "n": 1 },
-    { "op": "change_pol", "v": 100, "pol": "WFQ", "n": 3 },
-    { "op": "change_pol", "v": 101, "pol": "UNION", "n": 2 },
-    { "op": "change_pol", "v": 104, "pol": "SP", "n": 3 },
-    { "op": "change_pol", "v": 108, "pol": "RR", "n": 3 },
+    { "op": "set_policy", "v": 99, "pol": "UNION", "n": 1 },
+    { "op": "set_policy", "v": 100, "pol": "WFQ", "n": 3 },
+    { "op": "set_policy", "v": 101, "pol": "UNION", "n": 2 },
+    { "op": "set_policy", "v": 104, "pol": "SP", "n": 3 },
+    { "op": "set_policy", "v": 108, "pol": "RR", "n": 3 },
 
     { "op": "change_weight", "v": 100, "step": 1008, "weight": 3.0 },
     { "op": "change_weight", "v": 100, "step": 1009, "weight": 1.0 },

--- a/rio/tests/ir/jsons/complex_tree.json
+++ b/rio/tests/ir/jsons/complex_tree.json
@@ -103,12 +103,12 @@
     { "op": "set_policy", "v": 104, "pol": "SP", "n": 3 },
     { "op": "set_policy", "v": 108, "pol": "RR", "n": 3 },
 
-    { "op": "change_weight", "v": 100, "step": 1008, "weight": 3.0 },
-    { "op": "change_weight", "v": 100, "step": 1009, "weight": 1.0 },
-    { "op": "change_weight", "v": 100, "step": 1010, "weight": 2.0 },
+    { "op": "set_arm_meta", "v": 100, "step": 1008, "weight": 3.0 },
+    { "op": "set_arm_meta", "v": 100, "step": 1009, "weight": 1.0 },
+    { "op": "set_arm_meta", "v": 100, "step": 1010, "weight": 2.0 },
 
-    { "op": "change_weight", "v": 104, "step": 1002, "weight": 1.0 },
-    { "op": "change_weight", "v": 104, "step": 1003, "weight": 2.0 },
-    { "op": "change_weight", "v": 104, "step": 1004, "weight": 3.0 }
+    { "op": "set_arm_meta", "v": 104, "step": 1002, "weight": 1.0 },
+    { "op": "set_arm_meta", "v": 104, "step": 1003, "weight": 2.0 },
+    { "op": "set_arm_meta", "v": 104, "step": 1004, "weight": 3.0 }
   ]
 ]

--- a/rio/tests/ir/jsons/rr_ABC.json
+++ b/rio/tests/ir/jsons/rr_ABC.json
@@ -31,7 +31,7 @@
     { "op": "map", "v": 100, "class": "B", "step": 1001 },
     { "op": "map", "v": 100, "class": "C", "step": 1002 },
 
-    { "op": "change_pol", "v": 99, "pol": "UNION", "n": 1 },
-    { "op": "change_pol", "v": 100, "pol": "RR", "n": 3 }
+    { "op": "set_policy", "v": 99, "pol": "UNION", "n": 1 },
+    { "op": "set_policy", "v": 100, "pol": "RR", "n": 3 }
   ]
 ]

--- a/rio/tests/ir/test_compile.ml
+++ b/rio/tests/ir/test_compile.ml
@@ -30,7 +30,7 @@ let fifo_a_expected : commit =
     Assoc (99, "A");
     Assoc (100, "A");
     Map (99, "A", 999);
-    Change_pol (99, UNION, 1);
+    Set_policy (99, UNION, 1);
   ]
 
 let strict_abc_expected : commit =
@@ -59,8 +59,8 @@ let strict_abc_expected : commit =
     Map (100, "A", 1000);
     Map (100, "B", 1001);
     Map (100, "C", 1002);
-    Change_pol (99, UNION, 1);
-    Change_pol (100, SP, 3);
+    Set_policy (99, UNION, 1);
+    Set_policy (100, SP, 3);
     (* A is highest priority, then B, then C *)
     Change_weight (100, 1000, 1.0);
     Change_weight (100, 1001, 2.0);

--- a/rio/tests/ir/test_compile.ml
+++ b/rio/tests/ir/test_compile.ml
@@ -62,9 +62,9 @@ let strict_abc_expected : commit =
     Set_policy (99, UNION, 1);
     Set_policy (100, SP, 3);
     (* A is highest priority, then B, then C *)
-    Change_weight (100, 1000, 1.0);
-    Change_weight (100, 1001, 2.0);
-    Change_weight (100, 1002, 3.0);
+    Set_arm_meta (100, 1000, 1.0);
+    Set_arm_meta (100, 1001, 2.0);
+    Set_arm_meta (100, 1002, 3.0);
   ]
 
 let compile_tests =

--- a/rio/tests/ir/test_patch.ml
+++ b/rio/tests/ir/test_patch.ml
@@ -37,7 +37,7 @@ let strict_ab_to_abc_expected : commit =
     Assoc (103, "C");
     Map (100, "C", 1002);
     Change_arity (100, 3);
-    Change_weight (100, 1002, 3.0);
+    Set_arm_meta (100, 1002, 3.0);
   ]
 
 (* Mid-insert in SP: prev SP(A,C) compiled with positional weights A:1, C:2.
@@ -52,11 +52,11 @@ let strict_ac_to_abc_expected : commit =
     Assoc (103, "B");
     Map (100, "B", 1002);
     Change_arity (100, 3);
-    Change_weight (100, 1002, 2.0);
-    Change_weight (100, 1001, 3.0);
+    Set_arm_meta (100, 1002, 2.0);
+    Set_arm_meta (100, 1001, 3.0);
   ]
 
-(* RR arm appended at the root. Same shape as SP but no Change_weight. *)
+(* RR arm appended at the root. Same shape as SP but no Set_arm_meta. *)
 let rr_ab_to_abc_expected : commit =
   [
     Spawn (103, 1);
@@ -100,7 +100,7 @@ let one_arm_added_tests =
 
 (* wfq_BA compiles with vpifos 100 (root WFQ), 101 (A), 102 (B); steps 1000
    (A), 1001 (B). Adding FIFO C at slot 2 with weight 3 mints v=103 (PE 1)
-   and step 1002, plus a single Change_weight on the new step (no SP-style
+   and step 1002, plus a single Set_arm_meta on the new step (no SP-style
    shifts: WFQ slots are independent). *)
 let wfq_ba_to_abc_expected : commit =
   [
@@ -110,7 +110,7 @@ let wfq_ba_to_abc_expected : commit =
     Assoc (103, "C");
     Map (100, "C", 1002);
     Change_arity (100, 3);
-    Change_weight (100, 1002, 3.0);
+    Set_arm_meta (100, 1002, 3.0);
   ]
 
 (* complex_tree_partial: WFQ at root with two children — UNION[G,H] (weight 3)
@@ -122,7 +122,7 @@ let wfq_ba_to_abc_expected : commit =
    Patch adds the RR[D,E,F] subtree with weight 2 at slot 2: arm internals
    land on v=108 (RR, PE 1) plus 109/110/111 (D/E/F, PE 2); arm-internal
    adopts on steps 1007/1008/1009. The new parent→child step is 1010, with
-   Change_weight(100, 1010, 2.0). *)
+   Set_arm_meta(100, 1010, 2.0). *)
 let complex_tree_partial_to_full_expected : commit =
   [
     Spawn (108, 1);
@@ -150,7 +150,7 @@ let complex_tree_partial_to_full_expected : commit =
     Map (108, "F", 1009);
     Set_policy (108, RR, 3);
     Change_arity (100, 3);
-    Change_weight (100, 1010, 2.0);
+    Set_arm_meta (100, 1010, 2.0);
   ]
 
 let one_arm_added_wfq_tests =
@@ -166,8 +166,8 @@ let one_arm_added_wfq_tests =
 
 (* WFQ root with three FIFO arms: vpifo IDs 100 (root), 101/102/103 (A/B/C);
    adopt steps 1000/1001/1002. Bumping B's weight 1 -> 5 should emit a single
-   Change_weight on the root for B's step. *)
-let wfq_abc_to_one_weight_expected : commit = [ Change_weight (100, 1001, 5.0) ]
+   Set_arm_meta on the root for B's step. *)
+let wfq_abc_to_one_weight_expected : commit = [ Set_arm_meta (100, 1001, 5.0) ]
 
 let weight_changed_tests =
   [
@@ -191,7 +191,7 @@ let strict_abc_to_ab_expected : commit =
    weight 3.0, shifts to index 1 with weight 2.0. *)
 let strict_abc_to_ac_expected : commit =
   [
-    Change_weight (100, 1002, 2.0);
+    Set_arm_meta (100, 1002, 2.0);
     Change_arity (100, 2);
     Unmap (100, "B", 1001);
     Deassoc (100, "B");
@@ -239,7 +239,7 @@ let rr_ab_to_ad_expected : commit =
   ]
 
 (* SP[A,B] -> SP[A,C]: same shape as RR but in an SP parent. Positional
-   weights stay (slot 1 is still 2.0), so no Change_weight is emitted. *)
+   weights stay (slot 1 is still 2.0), so no Set_arm_meta is emitted. *)
 let strict_ab_to_ac_expected : commit =
   [
     Spawn (103, 1);
@@ -264,7 +264,7 @@ let one_arm_replaced_tests =
    for A/B/C on steps 1000/1001/1002. Replacing slot 2's arm (C → FIFO Z)
    *and* its weight (3 → 7) reuses step 1002: the new FIFO Z spawns on
    v=104 (PE 1), is [Designate]d onto v=103, ancestor routing on v=100
-   swings C → Z, the slot's weight gets a single [Change_weight], and
+   swings C → Z, the slot's weight gets a single [Set_arm_meta], and
    v=103 is GC'd. *)
 let wfq_abc_to_abz_diff_expected : commit =
   [
@@ -277,7 +277,7 @@ let wfq_abc_to_abz_diff_expected : commit =
     Map (100, "Z", 1002);
     Undesignate 103;
     GC 103;
-    Change_weight (100, 1002, 7.0);
+    Set_arm_meta (100, 1002, 7.0);
   ]
 
 let one_arm_replaced_wfq_tests =
@@ -468,9 +468,9 @@ let strict_abc_to_complex_tree_expected : commit =
     Set_policy (104, WFQ, 3);
     Set_policy (105, UNION, 2);
     Set_policy (108, RR, 3);
-    Change_weight (104, 1008, 3.0);
-    Change_weight (104, 1009, 1.0);
-    Change_weight (104, 1010, 2.0);
+    Set_arm_meta (104, 1008, 3.0);
+    Set_arm_meta (104, 1009, 1.0);
+    Set_arm_meta (104, 1010, 2.0);
     Emancipate (999, 99, 100);
     Adopt (999, 99, 104);
     Assoc (99, "G");
@@ -544,7 +544,7 @@ let one_arm_added_extends_pes_test =
       Map (102, "C", 1002);
       Set_policy (102, RR, 2);
       Change_arity (100, 2);
-      Change_weight (100, 1003, 2.0);
+      Set_arm_meta (100, 1003, 2.0);
     ]
   in
   assert_equal ~printer:Ir.string_of_commit expected c.commit

--- a/rio/tests/ir/test_patch.ml
+++ b/rio/tests/ir/test_patch.ml
@@ -406,8 +406,11 @@ let sub_pol_tests =
    (prev's root v=100), 1010 (RR). Each ancestor [Assoc]/[Map]s every
    class in its subtree; WFQ weights mirror the (pol, weight) sort
    order: 3, 1, 2. Final [Emancipate]/[Adopt] on the fake root swings its
-   single step from prev's old real root v100 to the new top v104. None of
-   prev's vpifos are respawned. *)
+   single step from prev's old real root v100 to the new top v104, and the
+   fake root gains [Assoc]/[Map] entries on its single step for the five
+   classes that [complex_tree] adds beyond [strict_ABC] (G, H, D, E, F in
+   the normalized preorder); the three carried-over classes (A, B, C) keep
+   their existing fake-root wiring. None of prev's vpifos are respawned. *)
 let strict_abc_to_complex_tree_expected : commit =
   [
     Spawn (104, 2);
@@ -465,6 +468,16 @@ let strict_abc_to_complex_tree_expected : commit =
     Change_weight (104, 1010, 2.0);
     Emancipate (999, 99, 100);
     Adopt (999, 99, 104);
+    Assoc (99, "G");
+    Assoc (99, "H");
+    Assoc (99, "D");
+    Assoc (99, "E");
+    Assoc (99, "F");
+    Map (99, "G", 999);
+    Map (99, "H", 999);
+    Map (99, "D", 999);
+    Map (99, "E", 999);
+    Map (99, "F", 999);
   ]
 
 let super_pol_tests =

--- a/rio/tests/ir/test_patch.ml
+++ b/rio/tests/ir/test_patch.ml
@@ -36,7 +36,7 @@ let strict_ab_to_abc_expected : commit =
     Assoc (100, "C");
     Assoc (103, "C");
     Map (100, "C", 1002);
-    Change_pol (100, SP, 3);
+    Change_arity (100, 3);
     Change_weight (100, 1002, 3.0);
   ]
 
@@ -51,7 +51,7 @@ let strict_ac_to_abc_expected : commit =
     Assoc (100, "B");
     Assoc (103, "B");
     Map (100, "B", 1002);
-    Change_pol (100, SP, 3);
+    Change_arity (100, 3);
     Change_weight (100, 1002, 2.0);
     Change_weight (100, 1001, 3.0);
   ]
@@ -64,7 +64,7 @@ let rr_ab_to_abc_expected : commit =
     Assoc (100, "C");
     Assoc (103, "C");
     Map (100, "C", 1002);
-    Change_pol (100, RR, 3);
+    Change_arity (100, 3);
   ]
 
 (* Deep arm add. complex_tree's normalized root is WFQ with children sorted
@@ -81,7 +81,7 @@ let complex_tree_add_deep_expected : commit =
     Assoc (112, "NEW");
     Map (100, "NEW", 1010);
     Map (108, "NEW", 1011);
-    Change_pol (108, RR, 4);
+    Change_arity (108, 4);
   ]
 
 let one_arm_added_tests =
@@ -109,7 +109,7 @@ let wfq_ba_to_abc_expected : commit =
     Assoc (100, "C");
     Assoc (103, "C");
     Map (100, "C", 1002);
-    Change_pol (100, WFQ, 3);
+    Change_arity (100, 3);
     Change_weight (100, 1002, 3.0);
   ]
 
@@ -148,8 +148,8 @@ let complex_tree_partial_to_full_expected : commit =
     Map (108, "D", 1007);
     Map (108, "E", 1008);
     Map (108, "F", 1009);
-    Change_pol (100, WFQ, 3);
-    Change_pol (108, RR, 3);
+    Set_policy (108, RR, 3);
+    Change_arity (100, 3);
     Change_weight (100, 1010, 2.0);
   ]
 
@@ -180,7 +180,7 @@ let weight_changed_tests =
 (* SP[A,B,C] -> SP[A,B]: drop C (last, index 2). No SP weight shifts. *)
 let strict_abc_to_ab_expected : commit =
   [
-    Change_pol (100, SP, 2);
+    Change_arity (100, 2);
     Unmap (100, "C", 1002);
     Deassoc (100, "C");
     Emancipate (1002, 100, 103);
@@ -192,7 +192,7 @@ let strict_abc_to_ab_expected : commit =
 let strict_abc_to_ac_expected : commit =
   [
     Change_weight (100, 1002, 2.0);
-    Change_pol (100, SP, 2);
+    Change_arity (100, 2);
     Unmap (100, "B", 1001);
     Deassoc (100, "B");
     Emancipate (1001, 100, 102);
@@ -202,7 +202,7 @@ let strict_abc_to_ac_expected : commit =
 (* RR[A,B,C] -> RR[A,B]: drop C from RR. No weight shifts (RR is unweighted). *)
 let rr_abc_to_ab_expected : commit =
   [
-    Change_pol (100, RR, 2);
+    Change_arity (100, 2);
     Unmap (100, "C", 1002);
     Deassoc (100, "C");
     Emancipate (1002, 100, 103);
@@ -310,7 +310,7 @@ let rr_ab_to_rr_def_expected : commit =
     Map (103, "D", 1002);
     Map (103, "E", 1003);
     Map (103, "F", 1004);
-    Change_pol (103, RR, 3);
+    Set_policy (103, RR, 3);
     Designate (100, 103);
     Unmap (99, "A", 999);
     Unmap (99, "B", 999);
@@ -348,7 +348,7 @@ let strict_ab_to_rr_ab_expected : commit =
     Assoc (105, "B");
     Map (103, "A", 1002);
     Map (103, "B", 1003);
-    Change_pol (103, RR, 2);
+    Set_policy (103, RR, 2);
     Designate (100, 103);
     GC 100;
     GC 101;
@@ -460,9 +460,9 @@ let strict_abc_to_complex_tree_expected : commit =
     Map (108, "D", 1005);
     Map (108, "E", 1006);
     Map (108, "F", 1007);
-    Change_pol (104, WFQ, 3);
-    Change_pol (105, UNION, 2);
-    Change_pol (108, RR, 3);
+    Set_policy (104, WFQ, 3);
+    Set_policy (105, UNION, 2);
+    Set_policy (108, RR, 3);
     Change_weight (104, 1008, 3.0);
     Change_weight (104, 1009, 1.0);
     Change_weight (104, 1010, 2.0);
@@ -537,8 +537,8 @@ let one_arm_added_extends_pes_test =
       Map (100, "C", 1003);
       Map (102, "B", 1001);
       Map (102, "C", 1002);
-      Change_pol (100, SP, 2);
-      Change_pol (102, RR, 2);
+      Set_policy (102, RR, 2);
+      Change_arity (100, 2);
       Change_weight (100, 1003, 2.0);
     ]
   in

--- a/rio/tests/ir/test_patch.ml
+++ b/rio/tests/ir/test_patch.ml
@@ -234,6 +234,7 @@ let rr_ab_to_ad_expected : commit =
     Deassoc (100, "B");
     Assoc (100, "D");
     Map (100, "D", 1001);
+    Undesignate 102;
     GC 102;
   ]
 
@@ -248,6 +249,7 @@ let strict_ab_to_ac_expected : commit =
     Deassoc (100, "B");
     Assoc (100, "C");
     Map (100, "C", 1001);
+    Undesignate 102;
     GC 102;
   ]
 
@@ -273,6 +275,7 @@ let wfq_abc_to_abz_diff_expected : commit =
     Deassoc (100, "C");
     Assoc (100, "Z");
     Map (100, "Z", 1002);
+    Undesignate 103;
     GC 103;
     Change_weight (100, 1002, 7.0);
   ]
@@ -322,6 +325,7 @@ let rr_ab_to_rr_def_expected : commit =
     Map (99, "D", 999);
     Map (99, "E", 999);
     Map (99, "F", 999);
+    Undesignate 100;
     GC 100;
     GC 101;
     GC 102;
@@ -350,6 +354,7 @@ let strict_ab_to_rr_ab_expected : commit =
     Map (103, "B", 1003);
     Set_policy (103, RR, 2);
     Designate (100, 103);
+    Undesignate 100;
     GC 100;
     GC 101;
     GC 102;

--- a/rio/tests/ir/test_pretty.ml
+++ b/rio/tests/ir/test_pretty.ml
@@ -41,7 +41,7 @@ let rr_ab_commit : commit =
     Assoc (b_leaf, "B");
     Map (root, "A", s_a);
     Map (root, "B", s_b);
-    Change_pol (root, RR, 2);
+    Set_policy (root, RR, 2);
   ]
 
 (* Pretty-print of [rr_ab_commit] above — the handwritten IR without a
@@ -60,7 +60,7 @@ let expected_rr_ab_handwritten =
       "assoc(v102, B)";
       "map(v100, A, step_1000)";
       "map(v100, B, step_1001)";
-      "change_pol(v100, RR, 2)";
+      "set_policy(v100, RR, 2)";
     ]
 
 (* Pretty-print of what [Ir.of_policy] actually emits for rr[A, B]: the
@@ -85,8 +85,8 @@ let expected_rr_ab_compiled =
       "map(v99, B, step_999)";
       "map(v100, A, step_1000)";
       "map(v100, B, step_1001)";
-      "change_pol(v99, UNION, 1)";
-      "change_pol(v100, RR, 2)";
+      "set_policy(v99, UNION, 1)";
+      "set_policy(v100, RR, 2)";
     ]
 
 let test_rr_ab_handwritten =


### PR DESCRIPTION
This and a few following PRs will change the code to bring it line with the paper. Unlike #117, this has some genuine changes to the expect-tests but I have checked those changes and believe them all to be corrections or improvements.

In this PR:
- Make the port root `Assoc` and `Map` correctly when a graft occurs
- Split `change_policy` into `set_policy` and `change_arity`, so we aren't always issuing the heavier-weight thing. `change_arity` fires at `Add` and `Remove` of arms. `set_policy` fires once, ever, per node: at its birth.
- Correctly issue the ISA instruction `undesignate`