### PR TITLE
Tidy up after many changes to code

### DIFF
--- a/rio/core/pol.ml
+++ b/rio/core/pol.ml
@@ -37,12 +37,21 @@ let rec sub cl st used (p : Ast.stream) : Ast.clss list * t =
       (used, WFQ (List.combine qs ws))
   | _ -> failwith "ERROR: unsupported policy"
 
+(* Within an SP, RR, or WFQ node, sibling order carries no semantics: the
+   discipline is defined by ranks, round-robin fairness, or per-arm weights,
+   not by source position. [normalize] uses that arm-order freedom to pick a
+   canonical sibling ordering, and the runtime echoes the normalized form
+   back to the user as the committed shape. Edits that only permute siblings
+   become no-ops after normalization (see "merely jumbled" tests in
+   tests/planner/test_planner.ml); edits that reorder *and* add or remove an
+   arm sniff as just the structural change, keeping the edit's footprint
+   small. *)
 let rec normalize p =
   match p with
   | FIFO _ -> p
   | SP (prs, designated) ->
-      (* SP arms canonicalize by rank ascending (the priority order is the
-         discipline-defining datum); ties break by arm content. *)
+      (* SP: rank ascending (the priority order is the discipline-defining
+         datum); ties break by arm content. *)
       SP
         ( List.map (fun (p, r) -> (normalize p, r)) prs
           |> List.sort (fun (p1, r1) (p2, r2) ->
@@ -51,8 +60,8 @@ let rec normalize p =
           designated )
   | RR ps -> RR (List.map normalize ps |> List.sort compare)
   | WFQ pws ->
-      (* WFQ arms canonicalize by arm content (weights are independent
-         shares; same-arm collision is the rare case); ties break by weight. *)
+      (* WFQ: arm content first (weights are independent shares; same-arm
+         collisions are rare); ties break by weight. *)
       WFQ
         (List.map (fun (p, w) -> (normalize p, w)) pws
         |> List.sort (fun (p1, w1) (p2, w2) ->

--- a/rio/core/pol.ml
+++ b/rio/core/pol.ml
@@ -75,6 +75,12 @@ let rec to_string p =
       let to_string (p, w) = fmt "(%s, %g)" (to_string p) w in
       fmt "wfq[%s]" (join pws to_string)
 
+let rec depth = function
+  | FIFO _ -> 0
+  | SP (prs, _) | WFQ prs ->
+      1 + List.fold_left max 0 (List.map (fun (p, _) -> depth p) prs)
+  | RR ps -> 1 + List.fold_left max 0 (List.map depth ps)
+
 let rec walk p path =
   match (p, path) with
   | _, [] -> p

--- a/rio/core/pol.ml
+++ b/rio/core/pol.ml
@@ -72,7 +72,7 @@ let rec to_string p =
       fmt "strict[%s]" (join prs to_string)
   | RR ps -> fmt "rr[%s]" (join ps to_string)
   | WFQ pws ->
-      let to_string (p, w) = fmt "(%s, %f)" (to_string p) w in
+      let to_string (p, w) = fmt "(%s, %g)" (to_string p) w in
       fmt "wfq[%s]" (join pws to_string)
 
 let rec walk p path =

--- a/rio/core/pol.ml
+++ b/rio/core/pol.ml
@@ -13,27 +13,28 @@ let rec lookup x = function
   | (v, p) :: t when v = x -> (p, t)
   | (_, _) :: t -> lookup x t
 
-let rec sub cl st used (p : Ast.stream) =
-  let sub_ps = List.map (sub cl st used) in
-  let claim c =
-    if List.mem c !used then raise (DuplicateClass c)
+let rec sub cl st used (p : Ast.stream) : Ast.clss list * t =
+  let claim used c =
+    if List.mem c used then raise (DuplicateClass c)
     else if not (List.mem c cl) then raise (UndeclaredClass c)
-    else used := c :: !used
+    else c :: used
   in
   match p with
   | Var x ->
       let p, st = lookup x st in
       sub cl st used p
-  | Fifo c ->
-      claim c;
-      FIFO c
+  | Fifo c -> (claim used c, FIFO c)
   | Strict prs ->
       let ps, rs = List.split prs in
-      SP (List.combine (sub_ps ps) rs, false)
-  | RoundRobin ps -> RR (sub_ps ps)
+      let used, qs = List.fold_left_map (sub cl st) used ps in
+      (used, SP (List.combine qs rs, false))
+  | RoundRobin ps ->
+      let used, qs = List.fold_left_map (sub cl st) used ps in
+      (used, RR qs)
   | WeightedFair pws ->
       let ps, ws = List.split pws in
-      WFQ (List.combine (sub_ps ps) ws)
+      let used, qs = List.fold_left_map (sub cl st) used ps in
+      (used, WFQ (List.combine qs ws))
   | _ -> failwith "ERROR: unsupported policy"
 
 let rec normalize p =
@@ -60,7 +61,8 @@ let rec normalize p =
 
 (* Look up any variables and substitute them in. Then normalize the resulting policy. *)
 let of_program (classes, assigns, ret) =
-  sub classes assigns (ref []) ret |> normalize
+  let _, p = sub classes assigns [] ret in
+  normalize p
 
 let rec to_string p =
   let fmt = Printf.sprintf in

--- a/rio/core/pol.mli
+++ b/rio/core/pol.mli
@@ -22,6 +22,11 @@ val of_program : Ast.program -> t
 
 val to_string : t -> string
 
+val depth : t -> int
+(** Tree depth of [p]: a [FIFO] leaf is depth 0, and each interior node adds
+    one level above its deepest child. Equals the number of PE levels the
+    policy needs below the port root. *)
+
 val walk : t -> int list -> t
 (** [walk p path] descends into [p] following each child index in [path].
     [walk p []] is [p]. Raises if the path goes through a [FIFO] leaf or out of

--- a/rio/core/pol.mli
+++ b/rio/core/pol.mli
@@ -23,9 +23,9 @@ val of_program : Ast.program -> t
 val to_string : t -> string
 
 val depth : t -> int
-(** Tree depth of [p]: a [FIFO] leaf is depth 0, and each interior node adds
-    one level above its deepest child. Equals the number of PE levels the
-    policy needs below the port root. *)
+(** Tree depth of [p]: a [FIFO] leaf is depth 0, and each interior node adds one
+    level above its deepest child. Equals the number of PE levels the policy
+    needs below the port root. *)
 
 val walk : t -> int list -> t
 (** [walk p path] descends into [p] following each child index in [path].

--- a/rio/delta/delta.ml
+++ b/rio/delta/delta.ml
@@ -16,14 +16,20 @@ type t =
       arm : Rio_core.Pol.t;
       meta : float option;
     }
+      (** Insert [arm] as a new child at [path]. [meta] is the new arm's
+          per-arm metadata: a rank for SP, a weight for WFQ, [None] for RR. *)
   | Remove of {
       path : path;
       arm : Rio_core.Pol.t;
     }
+      (** Remove the child at [path]; [arm] records the dropped subtree's
+          shape (carried so confinement reasoning can see what left). *)
   | ChangeMeta of {
       path : path;
       new_meta : float;
     }
+      (** Rebind the per-arm metadata of the child at [path] to [new_meta]
+          (rank for SP, weight for WFQ; never reaches RR). *)
   | Graft of path
       (** [prev] sits as a strict subtree of [next] at [path]:
           [next = ctx[prev]] where [ctx]'s hole is at [path]. *)

--- a/rio/delta/delta.ml
+++ b/rio/delta/delta.ml
@@ -16,20 +16,20 @@ type t =
       arm : Rio_core.Pol.t;
       meta : float option;
     }
-      (** Insert [arm] as a new child at [path]. [meta] is the new arm's
-          per-arm metadata: a rank for SP, a weight for WFQ, [None] for RR. *)
+      (** Insert [arm] as a new child at [path]. [meta] is the new arm's per-arm
+          metadata: a rank for SP, a weight for WFQ, [None] for RR. *)
   | Remove of {
       path : path;
       arm : Rio_core.Pol.t;
     }
-      (** Remove the child at [path]; [arm] records the dropped subtree's
-          shape (carried so confinement reasoning can see what left). *)
+      (** Remove the child at [path]; [arm] records the dropped subtree's shape
+          (carried so confinement reasoning can see what left). *)
   | ChangeMeta of {
       path : path;
       new_meta : float;
     }
-      (** Rebind the per-arm metadata of the child at [path] to [new_meta]
-          (rank for SP, weight for WFQ; never reaches RR). *)
+      (** Rebind the per-arm metadata of the child at [path] to [new_meta] (rank
+          for SP, weight for WFQ; never reaches RR). *)
   | Graft of path
       (** [prev] sits as a strict subtree of [next] at [path]:
           [next = ctx[prev]] where [ctx]'s hole is at [path]. *)

--- a/rio/ir/decorated.ml
+++ b/rio/ir/decorated.ml
@@ -191,17 +191,6 @@ let set_meta k new_m = function
       WFQ (v, list_replace_nth k (fun (s, c, _) -> (s, c, new_m)) es)
   | _ -> failwith "Decorated.set_meta: SP/WFQ only"
 
-(* Replace child at index [k], preserving the parent→child step (and SP rank /
-   WFQ weight). Used by [ArmReplaced]: the new arm rides on the existing
-   [step_k], with the old root [Designate]d as the new root's predecessor. *)
-let replace_arm k new_child = function
-  | FIFO _ -> failwith "Decorated.replace_arm: FIFO"
-  | RR (v, es) -> RR (v, list_replace_nth k (fun (s, _) -> (s, new_child)) es)
-  | SP (v, es, dg) ->
-      SP (v, list_replace_nth k (fun (s, _, r) -> (s, new_child, r)) es, dg)
-  | WFQ (v, es) ->
-      WFQ (v, list_replace_nth k (fun (s, _, w) -> (s, new_child, w)) es)
-
 let rec to_policy (d : t) : Rio_core.Pol.t =
   let module P = Rio_core.Pol in
   match d with

--- a/rio/ir/decorated.mli
+++ b/rio/ir/decorated.mli
@@ -96,10 +96,6 @@ val set_meta : int -> float -> t -> t
 (** Set the [k]-th child's per-arm meta (rank for SP, weight for WFQ). Errors on
     RR and FIFO. *)
 
-val replace_arm : int -> t -> t -> t
-(** Replace child at index [k], preserving the parent-to-child step (and WFQ
-    weight). Errors on FIFO. *)
-
 val to_policy : t -> Rio_core.Pol.t
 (** Erase decorations to recover the underlying source policy. Inverse of the
     pairing produced by [Ir.of_policy]. *)

--- a/rio/ir/decorated.mli
+++ b/rio/ir/decorated.mli
@@ -10,11 +10,14 @@ type t =
   | FIFO of vpifo * clss
   | SP of vpifo * (step * t * float) list * bool
       (** The trailing [bool] is the "designated" flag, mirroring
-          [Rio_core.Pol.SP]. A designated SP is the runtime SP* super-node
-          minted by [Designate]: two children at indices 0/1 (loser/survivor),
-          ranks 1.0/2.0. The DSL only produces undesignated SPs; the flag flips
-          to [true] inside [Ir.patch]'s Replace lowering and back to [false]
-          (implicitly, by collapsing back to the survivor) on [Undesignate]. *)
+          [Rio_core.Pol.SP] and the IR-side [Instr.SP_star] marker. A
+          designated SP is the runtime SP* super-node minted by [Designate]:
+          exactly two children at indices 0/1 (loser/survivor), ranks
+          1.0/2.0. The DSL only produces undesignated SPs; the flag flips to
+          [true] inside [Ir.patch]'s Replace lowering and back to [false]
+          (implicitly, by collapsing back to the survivor) on [Undesignate].
+          The same-PE invariant on (sp_v, loser_root, survivor_root) lives at
+          the IR boundary; see [Instr.SP_star]'s contract. *)
   | RR of vpifo * (step * t) list
   | WFQ of vpifo * (step * t * float) list
 

--- a/rio/ir/decorated.mli
+++ b/rio/ir/decorated.mli
@@ -10,14 +10,14 @@ type t =
   | FIFO of vpifo * clss
   | SP of vpifo * (step * t * float) list * bool
       (** The trailing [bool] is the "designated" flag, mirroring
-          [Rio_core.Pol.SP] and the IR-side [Instr.SP_star] marker. A
-          designated SP is the runtime SP* super-node minted by [Designate]:
-          exactly two children at indices 0/1 (loser/survivor), ranks
-          1.0/2.0. The DSL only produces undesignated SPs; the flag flips to
-          [true] inside [Ir.patch]'s Replace lowering and back to [false]
-          (implicitly, by collapsing back to the survivor) on [Undesignate].
-          The same-PE invariant on (sp_v, loser_root, survivor_root) lives at
-          the IR boundary; see [Instr.SP_star]'s contract. *)
+          [Rio_core.Pol.SP] and the IR-side [Instr.SP_star] marker. A designated
+          SP is the runtime SP* super-node minted by [Designate]: exactly two
+          children at indices 0/1 (loser/survivor), ranks 1.0/2.0. The DSL only
+          produces undesignated SPs; the flag flips to [true] inside
+          [Ir.patch]'s Replace lowering and back to [false] (implicitly, by
+          collapsing back to the survivor) on [Undesignate]. The same-PE
+          invariant on (sp_v, loser_root, survivor_root) lives at the IR
+          boundary; see [Instr.SP_star]'s contract. *)
   | RR of vpifo * (step * t) list
   | WFQ of vpifo * (step * t * float) list
 

--- a/rio/ir/instr.ml
+++ b/rio/ir/instr.ml
@@ -11,11 +11,24 @@ type pol_ty =
   | SP
   | WFQ
   | SP_star
-(* The runtime-only counterpart of [SP] used by [Designate]'s lowering:
-         marks a v as the head of a designated super-node so the substrate
-         allocates super-node hardware. Spawned via [Set_policy (v, SP_star,
-         2)] right after a [Designate]; cleared at [Undesignate] time. Never
-         emitted by [of_policy] or by the source DSL. *)
+(* SP_star: the IR-level marker that [v] hosts a designated super-node (an
+   SP* in the paper's terminology). Carries the contract:
+
+   - Shape. A designated super-node has exactly two children, adopted at
+     indices 0 (loser) and 1 (survivor) with [Set_arm_meta] ranks 1.0 and 2.0
+     respectively, so the loser is favored while it drains.
+   - Lifecycle. Emitted exactly once per super-node by [patch_designate] via
+     [Set_policy (sp_v, SP_star, 2)]; cleared implicitly at [Undesignate]
+     when [GC sp_v] retires the v. Never emitted by [of_policy] or by the
+     source DSL.
+   - Same-PE invariant (paper/code-divergences.md A4). [sp_v], the
+     loser-subtree root, and the survivor-subtree root are guaranteed to
+     live on the same PE. [patch_designate] places all three at
+     [pe_of_depth(arm_depth)] so the substrate may coalesce them into a
+     single physical slot; that coalescing is the substrate's prerogative,
+     not an ISA-level lowering choice.
+   - Mirror. [Decorated.SP]'s trailing [bool] flag is the decorated-tree
+     analogue at the source-shape level. *)
 
 type instr =
   | Spawn of vpifo * pe

--- a/rio/ir/ir.ml
+++ b/rio/ir/ir.ml
@@ -47,14 +47,6 @@ let make_counter ~start =
     incr n;
     !n
 
-let rec policy_depth (p : Rio_core.Pol.t) : int =
-  let module P = Rio_core.Pol in
-  match p with
-  | P.FIFO _ -> 0
-  | P.SP (prs, _) | P.WFQ prs ->
-      1 + List.fold_left max 0 (List.map (fun (p, _) -> policy_depth p) prs)
-  | P.RR ps -> 1 + List.fold_left max 0 (List.map policy_depth ps)
-
 (* ------------------------------------------------------------------ *)
 (* ID-space and fake-root constants.                                  *)
 (* ------------------------------------------------------------------ *)
@@ -198,7 +190,7 @@ let of_policy (p : Rio_core.Pol.t) : compiled =
       classes = frag.classes;
     }
   in
-  let pes = List.init (policy_depth p + 1) (fun d -> d) in
+  let pes = List.init (Rio_core.Pol.depth p + 1) (fun d -> d) in
   single
     ~commit:(Frag.to_commit (Frag.combine port_frag [ frag ]))
     ~decorated ~pes
@@ -268,7 +260,7 @@ let patch_one_arm_added ~prev ~arm_path ~arm ~meta =
   let parent_v, old_arity, pol_ty = parent_info parent in
   let fresh_v, fresh_s = counters_after prev in
   let arm_depth = List.length arm_path in
-  let new_pes = pes_extended_to_depth (arm_depth + policy_depth arm) prev.pes in
+  let new_pes = pes_extended_to_depth (arm_depth + Rio_core.Pol.depth arm) prev.pes in
   let pe_of_depth d = List.nth new_pes d in
   (* Compile the arm before allocating [new_step] so its internal IDs land
      lower — mirroring [of_policy]'s pre-order numbering. *)
@@ -356,7 +348,7 @@ let patch_remove ~prev ~arm_path =
 let patch_graft ~prev ~next ~path =
   let len = List.length path in
   let prev_max_depth = List.length prev.pes - 1 in
-  let next_max_depth = policy_depth next in
+  let next_max_depth = Rio_core.Pol.depth next in
   (* New PE assignment: layers above [prev] get fresh PEs, layers occupied
      by [prev] reuse [prev.pes] (so already-installed nodes keep their PEs),
      layers deeper than [prev] get more fresh PEs. *)
@@ -484,7 +476,7 @@ let patch_designate ~prev ~path ~(arm : Rio_core.Pol.t) =
   let loser_v = Decorated.root_vpifo loser in
   let loser_classes = Decorated.subtree_classes loser in
   let arm_depth = List.length path in
-  let new_pes = pes_extended_to_depth (arm_depth + policy_depth arm) prev.pes in
+  let new_pes = pes_extended_to_depth (arm_depth + Rio_core.Pol.depth arm) prev.pes in
   let pe_n = List.nth new_pes arm_depth in
   let pe_of_depth d = List.nth new_pes d in
   let fresh_v, fresh_s = counters_after prev in

--- a/rio/ir/ir.ml
+++ b/rio/ir/ir.ml
@@ -16,6 +16,10 @@ type compiled = {
 let single ~commit ~decorated ~pes =
   { steps = [ (Rio_planner.Planner.True, commit) ]; decorated; pes }
 
+(* Extract the single-step commit from a [compiled] built by [single]. The
+   [failwith] arm is a debug-time invariant assertion: every caller (currently
+   just the patch fold at the bottom of this file) holds a [compiled] that
+   was constructed via [single] and therefore has exactly one step. *)
 let commit_of_single c =
   match c.steps with
   | [ (_, cmt) ] -> cmt

--- a/rio/ir/ir.ml
+++ b/rio/ir/ir.ml
@@ -264,7 +264,9 @@ let patch_one_arm_added ~prev ~arm_path ~arm ~meta =
   let parent_v, old_arity, pol_ty = parent_info parent in
   let fresh_v, fresh_s = counters_after prev in
   let arm_depth = List.length arm_path in
-  let new_pes = pes_extended_to_depth (arm_depth + Rio_core.Pol.depth arm) prev.pes in
+  let new_pes =
+    pes_extended_to_depth (arm_depth + Rio_core.Pol.depth arm) prev.pes
+  in
   let pe_of_depth d = List.nth new_pes d in
   (* Compile the arm before allocating [new_step] so its internal IDs land
      lower — mirroring [of_policy]'s pre-order numbering. *)
@@ -480,7 +482,9 @@ let patch_designate ~prev ~path ~(arm : Rio_core.Pol.t) =
   let loser_v = Decorated.root_vpifo loser in
   let loser_classes = Decorated.subtree_classes loser in
   let arm_depth = List.length path in
-  let new_pes = pes_extended_to_depth (arm_depth + Rio_core.Pol.depth arm) prev.pes in
+  let new_pes =
+    pes_extended_to_depth (arm_depth + Rio_core.Pol.depth arm) prev.pes
+  in
   let pe_n = List.nth new_pes arm_depth in
   let pe_of_depth d = List.nth new_pes d in
   let fresh_v, fresh_s = counters_after prev in

--- a/rio/ir/ir.ml
+++ b/rio/ir/ir.ml
@@ -534,17 +534,48 @@ let patch_designate ~prev ~path ~(arm : Rio_core.Pol.t) =
   in
   single ~commit ~decorated:new_decorated ~pes:new_pes
 
+(* Per-node Deassoc emits within a subtree (paper sketch.md §3.4.3 / §6.2:
+   every leaf in T and every internal node within C@τ must be Deassoc'd in
+   addition to the ancestor chain above C@τ). Quiesce emits no Unmap: silenced
+   flows' Map entries must outlive the silencing so packets already in flight
+   can route through the chain on the way to pop. [Isa_unmap] is paired with
+   [Isa_emancipate] inside [Remove], which fires only after the drain. *)
+let rec quiesce_interior (d : Decorated.t) : instr list =
+  let v = Decorated.root_vpifo d in
+  match d with
+  | Decorated.FIFO (_, c) -> [ Deassoc (v, c) ]
+  | _ ->
+      let children =
+        match d with
+        | Decorated.RR (_, es) -> List.map snd es
+        | Decorated.SP (_, es, _) -> List.map (fun (_, c, _) -> c) es
+        | Decorated.WFQ (_, es) -> List.map (fun (_, c, _) -> c) es
+        | Decorated.FIFO _ -> assert false
+      in
+      let all_classes = List.concat_map Decorated.subtree_classes children in
+      let deassocs = List.map (fun c -> Deassoc (v, c)) all_classes in
+      let recurse = List.concat_map quiesce_interior children in
+      deassocs @ recurse
+
 (* [Quiesce path]: stop new traffic from arriving at the subtree at [path] by
-   tearing down its class-routing entries along the ancestor chain. In-flight
-   packets continue to dequeue. [den(Quiesce) = id], so the decorated tree is
-   unchanged.
+   Deassoc'ing its leaves' classes at every node from the port root down
+   through the target's interior to each leaf (paper §3.4.3 / §6.2). Quiesce
+   strictly emits Deassoc only, never Unmap: live Map entries are load-bearing
+   for in-flight packets that still need to route on the way to pop. The
+   matching Unmap fires later inside [Remove]. [den(Quiesce) = id], so the
+   decorated tree is unchanged.
 
    SP*-aware: when [path]'s direct parent is a designated SP, the slot is the
-   loser inside a super-node and shared classes between loser and survivor
-   must be preserved (the survivor still needs them once the SP* collapses).
-   Above SP*, only loser-only classes are torn down. At SP* itself, all
-   loser-side maps are torn down, and shared-class maps are swung from
-   [loser_step] to [surv_step] so post-Quiesce traffic flows to the survivor. *)
+   loser inside a super-node. Above SP*, only loser-only classes are
+   Deassoc'd; shared classes are preserved so the survivor still receives
+   traffic through them. At SP*, only loser-only classes are Deassoc'd, and
+   shared-class Map entries are swung from [loser_step] to [surv_step] so
+   post-Quiesce traffic flows to the survivor; this Map edit is the one
+   non-Deassoc instruction Quiesce emits today, and it's earmarked to move
+   into [Designate] (paper/code-divergences.md A3).
+   The interior walk runs in both branches: the loser's interior Deassocs
+   every target class top-to-bottom (shared classes included; the survivor
+   reaches its own leaves via a separate chain). *)
 let patch_quiesce ~prev ~path =
   let target = Decorated.walk prev.decorated path in
   let target_classes = Decorated.subtree_classes target in
@@ -558,16 +589,15 @@ let patch_quiesce ~prev ~path =
         | Decorated.SP _ -> Decorated.sp_designated p
         | _ -> false)
   in
+  let interior = quiesce_interior target in
   let commit =
     if not parent_is_designated_sp then
       let chain = full_chain_to ~prev path in
-      chain_emit (fun v s c -> Unmap (v, c, s)) chain target_classes
-      @ chain_emit (fun v _ c -> Deassoc (v, c)) chain target_classes
+      chain_emit (fun v _ c -> Deassoc (v, c)) chain target_classes @ interior
     else
       let parent_path, k = list_foot path in
       let sp_parent = Decorated.walk prev.decorated parent_path in
       let sp_v = Decorated.root_vpifo sp_parent in
-      let loser_step = Decorated.nth_step sp_parent k in
       let surv_idx = 1 - k in
       let surv_step = Decorated.nth_step sp_parent surv_idx in
       let survivor_classes =
@@ -580,11 +610,10 @@ let patch_quiesce ~prev ~path =
         List.filter (fun c -> List.mem c survivor_classes) target_classes
       in
       let chain_up = chain_above_slot ~prev parent_path in
-      chain_emit (fun v s c -> Unmap (v, c, s)) chain_up only_loser
-      @ chain_emit (fun v _ c -> Deassoc (v, c)) chain_up only_loser
-      @ List.map (fun c -> Unmap (sp_v, c, loser_step)) target_classes
+      chain_emit (fun v _ c -> Deassoc (v, c)) chain_up only_loser
       @ List.map (fun c -> Deassoc (sp_v, c)) only_loser
       @ List.map (fun c -> Map (sp_v, c, surv_step)) shared
+      @ interior
   in
   single ~commit ~decorated:prev.decorated ~pes:prev.pes
 

--- a/rio/ir/ir.ml
+++ b/rio/ir/ir.ml
@@ -471,11 +471,13 @@ let parent_edge ~prev path =
    PE [pe_of_depth(arm_depth)], so the SP* layer is "free" depth-wise. The
    substrate (Zhiyuan) coalesces all three onto one logical slot.
 
-   Class routing at SP*: loser's classes route via [loser_step] (favoring the
-   loser per ranks 1.0 < 2.0); survivor-only classes route via [surv_step].
-   Shared classes go to loser; [Quiesce] later swings them to the survivor as
-   it drains the loser. The chain above SP* gains [Assoc]/[Map] only for
-   classes new to the survivor — existing-class chain entries already point at
+   Class routing at SP*: loser-only classes route via [loser_step]; the
+   survivor's classes (shared and survivor-only alike) route via [surv_step].
+   Per paper §3.4.5, a label shared between the old subtree and the survivor
+   belongs to the survivor from [Designate]'s firing onward. The favoring of
+   the loser per ranks 1.0 < 2.0 still applies to loser-only classes routed
+   to [loser_step]. The chain above SP* gains [Assoc]/[Map] only for classes
+   new to the survivor — existing-class chain entries already point at
    [parent_step], which we rewire from loser to SP* via [Emancipate]+[Adopt]. *)
 let patch_designate ~prev ~path ~(arm : Rio_core.Pol.t) =
   let loser = Decorated.walk prev.decorated path in
@@ -493,6 +495,9 @@ let patch_designate ~prev ~path ~(arm : Rio_core.Pol.t) =
   let new_classes = arm_frag.classes in
   let only_new =
     List.filter (fun c -> not (List.mem c loser_classes)) new_classes
+  in
+  let loser_only =
+    List.filter (fun c -> not (List.mem c new_classes)) loser_classes
   in
   let sp_v = fresh_v () in
   let loser_step = fresh_s () in
@@ -514,8 +519,8 @@ let patch_designate ~prev ~path ~(arm : Rio_core.Pol.t) =
         ];
         List.map (fun c -> Assoc (sp_v, c)) loser_classes;
         List.map (fun c -> Assoc (sp_v, c)) only_new;
-        List.map (fun c -> Map (sp_v, c, loser_step)) loser_classes;
-        List.map (fun c -> Map (sp_v, c, surv_step)) only_new;
+        List.map (fun c -> Map (sp_v, c, loser_step)) loser_only;
+        List.map (fun c -> Map (sp_v, c, surv_step)) new_classes;
         chain_emit (fun v _ c -> Assoc (v, c)) chain_above_sp only_new;
         chain_emit (fun v s c -> Map (v, c, s)) chain_above_sp only_new;
         [ Set_policy (sp_v, SP_star, 2) ];
@@ -568,14 +573,12 @@ let rec quiesce_interior (d : Decorated.t) : instr list =
    SP*-aware: when [path]'s direct parent is a designated SP, the slot is the
    loser inside a super-node. Above SP*, only loser-only classes are
    Deassoc'd; shared classes are preserved so the survivor still receives
-   traffic through them. At SP*, only loser-only classes are Deassoc'd, and
-   shared-class Map entries are swung from [loser_step] to [surv_step] so
-   post-Quiesce traffic flows to the survivor; this Map edit is the one
-   non-Deassoc instruction Quiesce emits today, and it's earmarked to move
-   into [Designate] (paper/code-divergences.md A3).
-   The interior walk runs in both branches: the loser's interior Deassocs
-   every target class top-to-bottom (shared classes included; the survivor
-   reaches its own leaves via a separate chain). *)
+   traffic through them. At SP*, only loser-only classes are Deassoc'd;
+   shared-class Map entries already point at [surv_step] (installed by
+   [Designate] at firing time per paper §3.4.5), so Quiesce has no Map work
+   to do. The interior walk runs in both branches: the loser's interior
+   Deassocs every target class top-to-bottom (shared classes included; the
+   survivor reaches its own leaves via a separate chain). *)
 let patch_quiesce ~prev ~path =
   let target = Decorated.walk prev.decorated path in
   let target_classes = Decorated.subtree_classes target in
@@ -599,20 +602,15 @@ let patch_quiesce ~prev ~path =
       let sp_parent = Decorated.walk prev.decorated parent_path in
       let sp_v = Decorated.root_vpifo sp_parent in
       let surv_idx = 1 - k in
-      let surv_step = Decorated.nth_step sp_parent surv_idx in
       let survivor_classes =
         Decorated.subtree_classes (Decorated.nth_child sp_parent surv_idx)
       in
       let only_loser =
         List.filter (fun c -> not (List.mem c survivor_classes)) target_classes
       in
-      let shared =
-        List.filter (fun c -> List.mem c survivor_classes) target_classes
-      in
       let chain_up = chain_above_slot ~prev parent_path in
       chain_emit (fun v _ c -> Deassoc (v, c)) chain_up only_loser
       @ List.map (fun c -> Deassoc (sp_v, c)) only_loser
-      @ List.map (fun c -> Map (sp_v, c, surv_step)) shared
       @ interior
   in
   single ~commit ~decorated:prev.decorated ~pes:prev.pes

--- a/rio/planner/planner.ml
+++ b/rio/planner/planner.ml
@@ -157,6 +157,13 @@ let prune_down_to ~prev ~path () =
   in
   walk prev path [] @ [ (True, Delta.ChangeRoot (List.map (fun _ -> 0) path)) ]
 
+(* Sequence-shape introspection for the comparators' demotion paths:
+   [compare_children] and [compare_metaed_children] each call into [analyze]
+   recursively on children, then need to recognize "this inner sequence
+   describes a relationship between children that doesn't bubble up to the
+   outer slot" and demote to a slot-level give-up. The two predicates below
+   are the only such recognizers. *)
+
 (* Recognize a [PruneDownTo] sequence's tail: any sequence whose last step is
    [ChangeRoot]. Used by [compare_children]'s demotion match. *)
 let ends_in_change_root seq =

--- a/rio/planner/planner.ml
+++ b/rio/planner/planner.ml
@@ -179,30 +179,20 @@ let is_replace_root = function
 let rec is_sub_policy p1 p2 =
   if p1 = p2 then Some []
   else
+    let scan children ~arm =
+      let rec loop i = function
+        | [] -> None
+        | x :: t -> (
+            match is_sub_policy p1 (arm x) with
+            | Some path -> Some (i :: path)
+            | None -> loop (i + 1) t)
+      in
+      loop 0 children
+    in
     match p2 with
     | FIFO _ -> None
-    | SP (prs, _) | WFQ prs ->
-        let rec loop i = function
-          | [] -> None
-          | (p, _) :: t -> (
-              if p = p1 then Some [ i ]
-              else
-                match is_sub_policy p1 p with
-                | None -> loop (i + 1) t
-                | Some path -> Some (i :: path))
-        in
-        loop 0 prs
-    | RR ps ->
-        let rec loop i = function
-          | [] -> None
-          | p :: t -> (
-              if p = p1 then Some [ i ]
-              else
-                match is_sub_policy p1 p with
-                | None -> loop (i + 1) t
-                | Some path -> Some (i :: path))
-        in
-        loop 0 ps
+    | SP (prs, _) | WFQ prs -> scan prs ~arm:fst
+    | RR ps -> scan ps ~arm:Fun.id
 
 (* Same control flow as the old [Compare.compare_children], but each branch
    emits a [Planner.t] (sequence) rather than a single [Delta.t]. *)

--- a/rio/tests/ir/test_patch.ml
+++ b/rio/tests/ir/test_patch.ml
@@ -235,13 +235,7 @@ let meta_changed_tests =
    before emitting the structural teardown. *)
 let strict_abc_to_ab_expected =
   [
-    t_
-      [
-        Unmap (99, "C", 999);
-        Unmap (100, "C", 1002);
-        Deassoc (99, "C");
-        Deassoc (100, "C");
-      ];
+    t_ [ Deassoc (99, "C"); Deassoc (100, "C"); Deassoc (103, "C") ];
     e_ [ 2 ] [ Change_arity (100, 2); Emancipate (1002, 100, 103); GC 103 ];
   ]
 
@@ -250,26 +244,14 @@ let strict_abc_to_ab_expected =
    emitted for surviving siblings. *)
 let strict_abc_to_ac_expected =
   [
-    t_
-      [
-        Unmap (99, "B", 999);
-        Unmap (100, "B", 1001);
-        Deassoc (99, "B");
-        Deassoc (100, "B");
-      ];
+    t_ [ Deassoc (99, "B"); Deassoc (100, "B"); Deassoc (102, "B") ];
     e_ [ 1 ] [ Change_arity (100, 2); Emancipate (1001, 100, 102); GC 102 ];
   ]
 
 (* RR[A,B,C] -> RR[A,B]: drop C from RR. No weight shifts (RR is unweighted). *)
 let rr_abc_to_ab_expected =
   [
-    t_
-      [
-        Unmap (99, "C", 999);
-        Unmap (100, "C", 1002);
-        Deassoc (99, "C");
-        Deassoc (100, "C");
-      ];
+    t_ [ Deassoc (99, "C"); Deassoc (100, "C"); Deassoc (103, "C") ];
     e_ [ 2 ] [ Change_arity (100, 2); Emancipate (1002, 100, 103); GC 103 ];
   ]
 
@@ -333,12 +315,10 @@ let rr_ab_to_ad_expected =
       ];
     t_
       [
-        Unmap (99, "B", 999);
-        Unmap (100, "B", 1001);
         Deassoc (99, "B");
         Deassoc (100, "B");
-        Unmap (104, "B", 1002);
         Deassoc (104, "B");
+        Deassoc (102, "B");
       ];
     e_ [ 1; 0 ]
       [
@@ -379,12 +359,10 @@ let strict_ab_to_ac_expected =
       ];
     t_
       [
-        Unmap (99, "B", 999);
-        Unmap (100, "B", 1001);
         Deassoc (99, "B");
         Deassoc (100, "B");
-        Unmap (104, "B", 1002);
         Deassoc (104, "B");
+        Deassoc (102, "B");
       ];
     e_ [ 1; 0 ]
       [
@@ -437,12 +415,10 @@ let wfq_abc_to_abz_diff_expected =
       ];
     t_
       [
-        Unmap (99, "C", 999);
-        Unmap (100, "C", 1002);
         Deassoc (99, "C");
         Deassoc (100, "C");
-        Unmap (105, "C", 1003);
         Deassoc (105, "C");
+        Deassoc (103, "C");
       ];
     e_ [ 2; 0 ]
       [
@@ -523,14 +499,14 @@ let rr_ab_to_rr_def_expected =
       ];
     t_
       [
-        Unmap (99, "A", 999);
-        Unmap (99, "B", 999);
         Deassoc (99, "A");
         Deassoc (99, "B");
-        Unmap (107, "A", 1005);
-        Unmap (107, "B", 1005);
         Deassoc (107, "A");
         Deassoc (107, "B");
+        Deassoc (100, "A");
+        Deassoc (100, "B");
+        Deassoc (101, "A");
+        Deassoc (102, "B");
       ];
     e_ [ 0 ]
       [
@@ -583,10 +559,12 @@ let strict_ab_to_rr_ab_expected =
       ];
     t_
       [
-        Unmap (106, "A", 1004);
-        Unmap (106, "B", 1004);
         Map (106, "A", 1005);
         Map (106, "B", 1005);
+        Deassoc (100, "A");
+        Deassoc (100, "B");
+        Deassoc (101, "A");
+        Deassoc (102, "B");
       ];
     e_ [ 0 ]
       [
@@ -623,22 +601,10 @@ let whole_tree_replace_tests =
 let strict_abc_to_fifo_a_expected =
   [
     (* Retire([2]) C: Quiesce then Remove. *)
-    t_
-      [
-        Unmap (99, "C", 999);
-        Unmap (100, "C", 1002);
-        Deassoc (99, "C");
-        Deassoc (100, "C");
-      ];
+    t_ [ Deassoc (99, "C"); Deassoc (100, "C"); Deassoc (103, "C") ];
     e_ [ 2 ] [ Change_arity (100, 2); Emancipate (1002, 100, 103); GC 103 ];
     (* Retire([1]) B: Quiesce then Remove. *)
-    t_
-      [
-        Unmap (99, "B", 999);
-        Unmap (100, "B", 1001);
-        Deassoc (99, "B");
-        Deassoc (100, "B");
-      ];
+    t_ [ Deassoc (99, "B"); Deassoc (100, "B"); Deassoc (102, "B") ];
     e_ [ 1 ] [ Change_arity (100, 1); Emancipate (1001, 100, 102); GC 102 ];
     (* ChangeRoot([0]): swing the port root from v100 to v101 and GC the SP
        root. Dropped-class block is empty (B and C already drained). *)
@@ -916,34 +882,33 @@ let designate_root_test =
   assert_equal ~printer:Ir.string_of_commit expected (single_commit c)
 
 (* Quiesce slot 1 of rr[A,B]: tear down routing for class B along the
-   chain from the port root down to the slot's parent. den(Quiesce) = id,
-   so no shape change to the tree. *)
+   chain from the port root down to the slot's parent, then Deassoc the
+   FIFO B leaf itself. den(Quiesce) = id, so no shape change to the
+   tree. *)
 let quiesce_arm_test =
   "Quiesce: rr[A,B] at slot 1 (drains B)" >:: fun _ ->
   let prev = compile "rr_AB" in
   let c = Ir.patch_quiesce ~prev ~path:[ 1 ] in
   let expected : commit =
-    [
-      Unmap (99, "B", 999);
-      Unmap (100, "B", 1001);
-      Deassoc (99, "B");
-      Deassoc (100, "B");
-    ]
+    [ Deassoc (99, "B"); Deassoc (100, "B"); Deassoc (102, "B") ]
   in
   assert_equal ~printer:Ir.string_of_commit expected (single_commit c)
 
-(* Quiesce at root: tears down routing for every class on the port root.
-   The whole tree is being drained. *)
+(* Quiesce at root: Deassocs every leaf class at every node from the port
+   root down through the rr root to its leaves. The whole tree is being
+   drained. *)
 let quiesce_root_test =
   "Quiesce: rr[A,B] whole-tree" >:: fun _ ->
   let prev = compile "rr_AB" in
   let c = Ir.patch_quiesce ~prev ~path:[] in
   let expected : commit =
     [
-      Unmap (99, "A", 999);
-      Unmap (99, "B", 999);
       Deassoc (99, "A");
       Deassoc (99, "B");
+      Deassoc (100, "A");
+      Deassoc (100, "B");
+      Deassoc (101, "A");
+      Deassoc (102, "B");
     ]
   in
   assert_equal ~printer:Ir.string_of_commit expected (single_commit c)
@@ -1025,14 +990,14 @@ let giveup_idiom_test =
       Set_policy (104, SP_star, 2);
       Set_arm_meta (104, 1002, 1.0);
       Set_arm_meta (104, 1003, 2.0);
-      Unmap (99, "A", 999);
-      Unmap (99, "B", 999);
       Deassoc (99, "A");
       Deassoc (99, "B");
-      Unmap (104, "A", 1002);
-      Unmap (104, "B", 1002);
       Deassoc (104, "A");
       Deassoc (104, "B");
+      Deassoc (100, "A");
+      Deassoc (100, "B");
+      Deassoc (101, "A");
+      Deassoc (102, "B");
       Emancipate (999, 99, 104);
       Adopt (999, 99, 103);
       Undesignate 100;

--- a/rio/tests/ir/test_patch.ml
+++ b/rio/tests/ir/test_patch.ml
@@ -523,10 +523,11 @@ let rr_ab_to_rr_def_expected =
 (* Whole-tree replacement via constructor mismatch at the root: prev =
    sp[A,B] (vpifos 100/101/102), next = rr[A,B]: same children,
    different root policy. The class sets coincide ({A,B}={A,B}) so the
-   port root's existing routing is preserved (no chain-above edits)
-   and Quiesce's SP*-aware branch fires entirely at sp_v=106: unmap A
-   and B off loser_step and remap them onto surv_step so the survivor
-   takes over the moment the loser drains. *)
+   port root's existing routing is preserved (no chain-above edits).
+   Designate routes both shared classes through surv_step at sp_v=106
+   (paper §3.4.5: shared classes belong to the survivor from Designate's
+   firing onward), and Quiesce's SP*-aware branch has no loser-only work
+   to do at sp_v: only the loser interior drains. *)
 let strict_ab_to_rr_ab_expected =
   [
     t_
@@ -551,16 +552,14 @@ let strict_ab_to_rr_ab_expected =
         Adopt (999, 99, 106);
         Assoc (106, "A");
         Assoc (106, "B");
-        Map (106, "A", 1004);
-        Map (106, "B", 1004);
+        Map (106, "A", 1005);
+        Map (106, "B", 1005);
         Set_policy (106, SP_star, 2);
         Set_arm_meta (106, 1004, 1.0);
         Set_arm_meta (106, 1005, 2.0);
       ];
     t_
       [
-        Map (106, "A", 1005);
-        Map (106, "B", 1005);
         Deassoc (100, "A");
         Deassoc (100, "B");
         Deassoc (101, "A");

--- a/rio/tests/planner/test_planner.ml
+++ b/rio/tests/planner/test_planner.ml
@@ -58,6 +58,11 @@ let same =
     make_planner_test "same program twice" "strict_ABC" "strict_ABC" [];
     make_planner_test "merely jumbled in RR" "rr_ABC" "rr_BAC" [];
     make_planner_test "merely jumbled in WFQ" "wfq_ABC" "wfq_ABC_jumbled" [];
+    (* strict_AB_swapped has the same (arm, rank) pairs as strict_AB but
+       lists them in swapped source order; [Pol.normalize]'s rank sort
+       canonicalizes the two to the same shape. *)
+    make_planner_test "merely source-swapped in SP" "strict_AB"
+      "strict_AB_swapped" [];
   ]
 
 (* [Add] fires on a single-arm insertion at any position of an RR/SP parent

--- a/rio/tests/progs/work_conserving/strict_AB_swapped.sched
+++ b/rio/tests/progs/work_conserving/strict_AB_swapped.sched
@@ -1,0 +1,10 @@
+classes A, B;
+
+// Source-order swapped vs strict_AB.sched (B first, then A), but the rank
+// assignments are unchanged: A still ranks 1 (higher priority), B still ranks
+// 2 (lower priority). Pol.normalize sorts SP arms by rank ascending, so this
+// canonicalizes to the same shape as strict_AB.
+
+policy = strict[(B, 2), (A, 1)];
+
+return policy


### PR DESCRIPTION
This is an omnibus PR which will tidy up after the 6 PRs that brought the code closer to the paper. There will be some cosmetic/refactoring issues and some genuine bugs. I will list them as we go.

- [x] Delete function `replace_arm`, which was not being used anymore. No change to tests.
- [x] When lowering `Quiesce` to ISA, remember that the `Deassoc` commands need to applied into the quiesced subtree too, not just above the subtree. Changes expect-tests (adds more `Deassoc`s).
- [x] `Quiesce` must emit `Deassoc` but not `Unmap`. Changes expect-tests (removes several `Unmap`s).
- [x] Fix a bug in how the idiom `Designate`; `Quiesce`, `Undesignate` were workging. Now aligns with the paper. 

