### PR TITLE
Make the planner look at flow sets

### DIFF
--- a/paper/sketch.md
+++ b/paper/sketch.md
@@ -1241,13 +1241,16 @@ Cases 4 and 5 are the descent mechanism: when the difference sits one level down
    Symmetric to the previous case.
 
 4. **`RR` at the current level, child lists of equal length.**
-   The planner walks each slot independently and emits one slot-level edit per diverging position; slot-level edits target distinct indices and so concatenate freely in ascending order.
+   When the children's class-label sets reveal a cleaner cross-slot pairing than slot position does (a slot's arm in `p1` shares labels with a different slot's arm in `p2`), the planner takes case 8's label-overlap alignment instead.
+   Otherwise it walks each slot independently and emits one slot-level edit per diverging position; slot-level edits target distinct indices and so concatenate freely in ascending order.
    At a slot whose arm agrees, nothing is emitted.
    At a slot whose arm differs, recurse on the inner pair and dispatch on the inner shape: a non-bubbleable inner (single `Graft`, or a sequence ending in `ChangeRoot`) demotes to a slot-level `Replace` at the outer position; any other inner sequence bubbles via index-prepending.
    §5.3 covers the demotion wrinkle.
 
 5. **`SP` or `WFQ` at the current level, child lists of equal length.**
-   The planner walks each slot independently and emits one slot-level edit per diverging position; slot-level edits target distinct indices and so concatenate freely in ascending order.
+   When `p1` and `p2` carry the same multiset of arms (the operator has simply re-weighted or re-ranked existing arms, which §3.2's normalization re-sorts into possibly-different slots), the planner emits one `ChangeMeta` per slot whose meta has moved and is done at this level.
+   Otherwise, when the children's class-label sets reveal a cleaner cross-slot pairing than slot position does, the planner takes case 8's label-overlap alignment.
+   Otherwise it walks each slot independently and emits one slot-level edit per diverging position; slot-level edits target distinct indices and so concatenate freely in ascending order.
    At a slot whose arm and metadata both agree, nothing is emitted.
    At a slot whose metadata differs but whose arm does not, emit `ChangeMeta(path, meta)` for that slot.
    At a slot whose arm differs (with or without a metadata change at the same slot), recurse on the inner pair and dispatch on the inner shape: a `Replace`-root inner takes any metadata change as a trailing `ChangeMeta` of its bubbled emission; a non-bubbleable inner (single `Graft`, or a sequence ending in `ChangeRoot`) demotes to a slot-level `Replace` at the outer position, carrying the metadata when present; any clean smaller inner edit bubbles via index-prepending and, when the metadata also changed, picks up a separate `ChangeMeta` step at the slot.
@@ -1264,14 +1267,15 @@ Cases 4 and 5 are the descent mechanism: when the difference sits one level down
    `SlowRetire` remains available to imperative-mode authors.
    At an `SP` or `WFQ` parent each shared arm whose metadata differs additionally contributes a `ChangeMeta` step (in `p2`'s post-`Retire` frame) after all `Retire`s have fired; the surplus arms' metadata is discarded, since `Retire` removes the slot wholesale.
 
-8. **Same constructor at the current level, lengths differ, and pairing arms by label-set overlap admits an alignment.**
-   When cases 6 and 7 fail because some shared arm has itself morphed structurally, the planner relaxes its embedding check.
-   Arms whose class-label sets overlap pair up by a greedy left-to-right walk; arms whose labels appear nowhere on the opposing side are treated as pure `Add`s when `p2` is longer or pure `Retire`s when `p1` is longer.
-   `Add`s fire first in ascending index order; `Retire`s fire first in descending index order; matched-pair edits then recurse on the inner pair and bubble to the slot's position in `p2`'s post-mutation frame, subject to the §5.3 demotion rule.
-   At an `SP` or `WFQ` parent each surplus `Add` carries its meta, and a matched pair whose metas also differ folds a `ChangeMeta` into the recursive edit (either as a trailing step on a clean bubble or as the meta argument to a demoted `Replace`).
-   The pairing relies on §3.2's leaf-partition validity: a class label identifies a unique flow across the whole policy, so a repeated label between an arm in `p1` and an arm in `p2` is evidence that the same host arm has morphed, and an arm whose labels appear nowhere on the opposing side is necessarily a fresh sibling (or, in the `p1`-longer direction, a vanishing one).
+8. **Same constructor at the current level, with arms aligned by class-label overlap.**
+   Cases 4 and 5 pivot here when class-labels reveal a cross-slot correspondence, and cases 6 and 7 fall through here when the lengths differ but neither side's arms are a subset of the other's.
+   Arms in `p1` and `p2` whose class-label sets overlap pair up by a greedy left-to-right walk.
+   Arms in `p1` with no overlapping partner in `p2` retire; arms in `p2` with no overlapping partner in `p1` are added; the two can coexist at the same parent.
+   `Retire`s fire first in descending `p1`-index order, `Add`s next in ascending `p2`-index order; matched-pair edits then recurse on the inner pair and bubble to the slot's position in `p2`'s post-mutation frame, subject to the §5.3 demotion rule.
+   At an `SP` or `WFQ` parent each `Add` carries its meta, and a matched pair whose metas also differ folds a `ChangeMeta` into the recursive edit (either as a trailing step on a clean bubble or as the meta argument to a demoted `Replace`).
+   The pairing relies on §3.2's leaf-partition validity: a class label identifies a unique flow across the whole policy, so a repeated label between an arm in `p1` and an arm in `p2` is evidence that the same host arm has morphed, and an arm whose labels appear nowhere on the opposing side is necessarily a fresh sibling or a vanishing one.
    The greedy walk is not complete: when more than one alignment satisfies the label-overlap constraint, the first one found is taken without a notion of cost (§5.4).
-   When the greedy walk leaves arms unpaired on the shorter side, the case fails and the planner falls through to case 9.
+   When no shared label admits even a single match, the case fails and the planner falls through to case 9; this keeps wholesale divergence (no anchoring overlap) from emptying the parent mid-sequence.
 
 9. **Anything else.**
    Emit `Replace` at the current level.

--- a/paper/sketch.md
+++ b/paper/sketch.md
@@ -1223,7 +1223,7 @@ We claim only that whatever sequence it emits is safe (§3.4) and no worse than 
 ### 5.2 The case analysis
 
 The planner steps through the following cases in order, emitting at the first match.
-Each call examines the current pair `(p1, p2)`: cases 1-3 test the two trees as wholes; cases 4-7 fire when the roots agree and the local difference has a recognized shape; case 8 catches everything else.
+Each call examines the current pair `(p1, p2)`: cases 1-3 test the two trees as wholes; cases 4-8 fire when the roots agree and the local difference has a recognized shape; case 9 catches everything else.
 Cases 4 and 5 are the descent mechanism: when the difference sits one level down, they re-enter this case analysis on the differing slot, and whatever case fires at the deeper level has its emission re-targeted via index prepending on the way back up.
 
 1. **`p1 = p2`.**
@@ -1264,15 +1264,23 @@ Cases 4 and 5 are the descent mechanism: when the difference sits one level down
    `SlowRetire` remains available to imperative-mode authors.
    At an `SP` or `WFQ` parent each shared arm whose metadata differs additionally contributes a `ChangeMeta` step (in `p2`'s post-`Retire` frame) after all `Retire`s have fired; the surplus arms' metadata is discarded, since `Retire` removes the slot wholesale.
 
-8. **Anything else.**
+8. **`RR` at the current level, lengths differ, and pairing arms by label-set overlap admits an alignment.**
+   When cases 6 and 7 fail at an `RR` parent because some shared arm has itself morphed structurally, the planner relaxes its embedding check.
+   Arms whose class-label sets overlap pair up by a greedy left-to-right walk; arms whose labels appear nowhere on the opposing side are treated as pure `Add`s when `p2` is longer or pure `Retire`s when `p1` is longer.
+   `Add`s fire first in ascending index order; `Retire`s fire first in descending index order; matched-pair edits then recurse on the inner pair and bubble to the slot's position in `p2`'s post-mutation frame, subject to the §5.3 demotion rule.
+   The pairing relies on §3.2's leaf-partition validity: a class label identifies a unique flow across the whole policy, so a repeated label between an arm in `p1` and an arm in `p2` is evidence that the same host arm has morphed, and an arm whose labels appear nowhere on the opposing side is necessarily a fresh sibling (or, in the `p1`-longer direction, a vanishing one).
+   The greedy walk is not complete: when more than one alignment satisfies the label-overlap constraint, the first one found is taken without a notion of cost (§5.4).
+   When the greedy walk leaves arms unpaired on the shorter side, the case fails and the planner falls through to case 9.
+
+9. **Anything else.**
    Emit `Replace` at the current level.
-   "Anything else" covers same-level shapes the planner does not recognize: constructor mismatch (e.g., `SP` vs. `RR`), and child lists of unequal length where neither's children are a subset of the other's (so additions and removals would have to mix at the same parent).
+   "Anything else" covers same-level shapes the planner does not recognize: constructor mismatch (e.g., `SP` vs. `RR`), and child lists of unequal length where neither's children are a subset of the other's and case 8 either does not apply (an `SP` or `WFQ` parent) or fails to find an alignment.
 
    The recursion does significant work here.
-   Cases 1-7 are tried at every level the recursion visits, and cases 4 and 5 descend into agreeing slots of their parents.
-   By the time case 8 fires at level `k`, every shallower level has matched a tight case; the resulting `Replace` therefore lands at the _deepest slot the planner could isolate the difference to_, leaving every ancestor's other subtrees running undisturbed.
+   Cases 1-8 are tried at every level the recursion visits, and cases 4, 5, and 8 descend into agreeing or label-overlapping slots of their parents.
+   By the time case 9 fires at level `k`, every shallower level has matched a tight case; the resulting `Replace` therefore lands at the _deepest slot the planner could isolate the difference to_, leaving every ancestor's other subtrees running undisturbed.
    The slot-level `Replace` is the §5.1 idiom with a non-empty path: it wraps only the slot's subtree, quiesces only that subtree, and rewires only the parent edge into it.
-   The worst case is a root-level `Replace([], p2)` (§5.1), reached only when case 8 fires at the root with no recursive descent.
+   The worst case is a root-level `Replace([], p2)` (§5.1), reached only when case 9 fires at the root with no recursive descent.
 
 ### 5.3 Demotion: when an inner result cannot bubble
 
@@ -1286,7 +1294,7 @@ Recursing on `B` vs. `C(B)` falls into case 2: `B` embeds in `C(B)`, so the inne
 Bubbling this inner step by prepending index 1 would yield `[(true, Graft(C(□)))]` _at the outer slot_, which is not the edit the operator requested: `Graft`'s denotation acts on the whole running tree (per §3.4.8), not on the bubbled-up slot, so the prepended path would mis-describe the edit.
 
 The planner detects this shape (the inner result is a single `Graft` step, or it ends in `ChangeRoot` as `PruneDownTo`'s tail does) and _demotes_ to a slot-level `Replace` at the outer position; when the demoting recognizer is case 5 and the slot's metadata is also changing, the demoted `Replace` carries the new metadata as its trailing `ChangeMeta` step.
-Demotion is a deliberate downgrade in confinement (we land at case 8 for that slot rather than the tight inner `δ` we hoped for), but it is the price of recognizing that `Graft` and `PruneDownTo` describe _whole-tree edits only_.
+Demotion is a deliberate downgrade in confinement (we land at case 9 for that slot rather than the tight inner `δ` we hoped for), but it is the price of recognizing that `Graft` and `PruneDownTo` describe _whole-tree edits only_.
 
 A future planner could do better here.
 A multi-`Add`-aware planner would recognize the running example as a single `Add` at the new `C` node (after standing it up via an outer rewrite), and avoid the demotion.
@@ -1298,12 +1306,12 @@ Three deliberate non-features, each a candidate for future work.
 
 - _No cost model._
   The case analysis is shape-based, not cost-weighted.
-  A cost-aware planner could prefer different decompositions (e.g., several small `Add`s vs. a single root-level `Replace`) based on per-flow drop and delay tolerances or per-PE budgets; we leave this to future work.
-- _No alignment-aware recognition when the arm projection fails to embed._
-  Cases 6 and 7 require one child list to be a subset of the other.
-  When the two child lists overlap but neither is a subset (for instance, `RR(A, SP(B, C, D))` becoming `RR(A, SP(B, C), E)`, where slot 1 is structurally edited and slot 2 is a fresh arm), case 8 fires.
-  Distinguishing this from a wholesale outer `Replace` would need a flow-identity signal the planner does not currently track.
-  A planner that emitted such compositions would be a strict improvement, and the §4.3 pol-level check would catch any unsound such composition, so the cost of trying is bounded by the check's overhead.
+  A cost-aware planner could prefer different decompositions (e.g., several small `Add`s vs. a single root-level `Replace`) based on per-flow drop and delay tolerances or per-PE budgets; case 8's label-set pairing is one place this would bite, since the greedy walk takes the first admissible alignment without ranking competitors.
+  We leave both questions to future work.
+- _No alignment-aware recognition at `SP` or `WFQ` parents._
+  Case 8 above handles the alignment-aware recognition at `RR` parents, whose children are unordered (each index has no scheduling meaning of its own).
+  At `SP` and `WFQ` parents cases 6 and 7 still require the arm projection to embed strictly: a length change combined with an inner morph at a shared arm (for instance, an `SP` whose lower-priority subtree was edited at the same time as a sibling appeared at a fresh priority) falls through to case 9.
+  The mechanism transports to metaed parents in principle (label-set pairing on the arm projection, then a recursive analyze plus a `ChangeMeta` at each surviving slot whose metadata also moved), but the implementation is not in the planner today.
 - _No imperative-mode service._
   The planner serves declarative mode only.
   Imperative-mode authoring (§4.3) goes through the pol-level check directly, with the operator naming each `δ` themselves; the planner is not consulted.

--- a/paper/sketch.md
+++ b/paper/sketch.md
@@ -1264,17 +1264,18 @@ Cases 4 and 5 are the descent mechanism: when the difference sits one level down
    `SlowRetire` remains available to imperative-mode authors.
    At an `SP` or `WFQ` parent each shared arm whose metadata differs additionally contributes a `ChangeMeta` step (in `p2`'s post-`Retire` frame) after all `Retire`s have fired; the surplus arms' metadata is discarded, since `Retire` removes the slot wholesale.
 
-8. **`RR` at the current level, lengths differ, and pairing arms by label-set overlap admits an alignment.**
-   When cases 6 and 7 fail at an `RR` parent because some shared arm has itself morphed structurally, the planner relaxes its embedding check.
+8. **Same constructor at the current level, lengths differ, and pairing arms by label-set overlap admits an alignment.**
+   When cases 6 and 7 fail because some shared arm has itself morphed structurally, the planner relaxes its embedding check.
    Arms whose class-label sets overlap pair up by a greedy left-to-right walk; arms whose labels appear nowhere on the opposing side are treated as pure `Add`s when `p2` is longer or pure `Retire`s when `p1` is longer.
    `Add`s fire first in ascending index order; `Retire`s fire first in descending index order; matched-pair edits then recurse on the inner pair and bubble to the slot's position in `p2`'s post-mutation frame, subject to the §5.3 demotion rule.
+   At an `SP` or `WFQ` parent each surplus `Add` carries its meta, and a matched pair whose metas also differ folds a `ChangeMeta` into the recursive edit (either as a trailing step on a clean bubble or as the meta argument to a demoted `Replace`).
    The pairing relies on §3.2's leaf-partition validity: a class label identifies a unique flow across the whole policy, so a repeated label between an arm in `p1` and an arm in `p2` is evidence that the same host arm has morphed, and an arm whose labels appear nowhere on the opposing side is necessarily a fresh sibling (or, in the `p1`-longer direction, a vanishing one).
    The greedy walk is not complete: when more than one alignment satisfies the label-overlap constraint, the first one found is taken without a notion of cost (§5.4).
    When the greedy walk leaves arms unpaired on the shorter side, the case fails and the planner falls through to case 9.
 
 9. **Anything else.**
    Emit `Replace` at the current level.
-   "Anything else" covers same-level shapes the planner does not recognize: constructor mismatch (e.g., `SP` vs. `RR`), and child lists of unequal length where neither's children are a subset of the other's and case 8 either does not apply (an `SP` or `WFQ` parent) or fails to find an alignment.
+   "Anything else" covers same-level shapes the planner does not recognize: constructor mismatch (e.g., `SP` vs. `RR`), and child lists of unequal length where neither's children are a subset of the other's and case 8's label-set walk fails to find an alignment.
 
    The recursion does significant work here.
    Cases 1-8 are tried at every level the recursion visits, and cases 4, 5, and 8 descend into agreeing or label-overlapping slots of their parents.
@@ -1302,16 +1303,12 @@ We leave that to future work; see §5.4.
 
 ### 5.4 What the planner does not do today
 
-Three deliberate non-features, each a candidate for future work.
+Two deliberate non-features, each a candidate for future work.
 
 - _No cost model._
   The case analysis is shape-based, not cost-weighted.
   A cost-aware planner could prefer different decompositions (e.g., several small `Add`s vs. a single root-level `Replace`) based on per-flow drop and delay tolerances or per-PE budgets; case 8's label-set pairing is one place this would bite, since the greedy walk takes the first admissible alignment without ranking competitors.
   We leave both questions to future work.
-- _No alignment-aware recognition at `SP` or `WFQ` parents._
-  Case 8 above handles the alignment-aware recognition at `RR` parents, whose children are unordered (each index has no scheduling meaning of its own).
-  At `SP` and `WFQ` parents cases 6 and 7 still require the arm projection to embed strictly: a length change combined with an inner morph at a shared arm (for instance, an `SP` whose lower-priority subtree was edited at the same time as a sibling appeared at a fresh priority) falls through to case 9.
-  The mechanism transports to metaed parents in principle (label-set pairing on the arm projection, then a recursive analyze plus a `ChangeMeta` at each surviving slot whose metadata also moved), but the implementation is not in the planner today.
 - _No imperative-mode service._
   The planner serves declarative mode only.
   Imperative-mode authoring (§4.3) goes through the pol-level check directly, with the operator naming each `δ` themselves; the planner is not consulted.

--- a/rio/planner/planner.ml
+++ b/rio/planner/planner.ml
@@ -48,42 +48,83 @@ let labels_overlap a b =
   let lb = arm_labels b in
   List.exists (fun x -> List.mem x lb) (arm_labels a)
 
-(* Greedy label-set alignment for the comparators' length-differing
-   branches: when [insertions] fails because a matched arm has morphed
-   (lengths differ AND a shared arm changed structurally), line up [short]
-   inside [long] by overlapping label sets instead of by structural
-   equality. Walks both lists once: pairs the heads if their label sets
-   overlap, otherwise consumes the long head as a pure surplus (an [Add] in
-   the [-1] branch, a [Retire] in the [1] branch). If [short] still has
-   arms after [long] is exhausted, no alignment was found; the caller falls
-   through to give-up. Returns [(matches, surplus)] where each match is
-   [(long_idx, short_arm, long_arm)] in [long]'s frame and each surplus is
-   [(long_idx, long_arm)]. Both [compare_children] (RR) and
-   [compare_metaed_children] (SP/WFQ) use this fallback; the metaed callers
-   read the meta off [ms1]/[ms2] by position. Greedy left-to-right; suffices
-   for the cases currently in the test suite, and the cost-model question
-   of which alignment to prefer when several are admissible is parked in
-   [paper/sketch.md] §5.4. *)
-let align_by_labels short long_ =
-  let rec loop short long_ i =
-    match (short, long_) with
-    | [], [] -> Some ([], [])
-    | [], r :: rt ->
-        Option.map
-          (fun (matches, surplus) -> (matches, (i, r) :: surplus))
-          (loop [] rt (i + 1))
-    | _ :: _, [] -> None
-    | l :: lt, r :: rt ->
-        if labels_overlap l r then
-          Option.map
-            (fun (matches, surplus) -> ((i, l, r) :: matches, surplus))
-            (loop lt rt (i + 1))
-        else
-          Option.map
-            (fun (matches, surplus) -> (matches, (i, r) :: surplus))
-            (loop short rt (i + 1))
+(* Bidirectional label-set alignment, used by the comparators' fallback
+   branches when [insertions]'s strict subsequence check has failed. Pairs
+   arms in [ps1] and [ps2] by class-label overlap (paper sketch.md sec3.2
+   leaf-partition validity guarantees at most one partner per arm).
+   Unmatched arms on either side flow through: [ps1_only] becomes retires,
+   [ps2_only] becomes adds. The same call therefore handles pure-add,
+   pure-retire, and the mixed case where a single parent simultaneously
+   retires some arms and adds others (e.g. [RR(A, B) -> RR(A, C, D)]:
+   matches A-A, retires B, adds C and D). Returns matches as
+   [(i1, j2, arm1, arm2)] in their original frames; the caller emits
+   retires (descending [ps1] index) before adds (ascending [ps2] index) so
+   that path frames stay coherent (paper sketch.md sec5.2 case 8).
+
+   Returns [None] (caller falls back to slot-level [Replace]) if any arm
+   overlaps more than one on the other side, or if the matching reorders
+   slots non-monotonically. [Pol.normalize] sorts siblings into a canonical
+   order, so post-normalize inputs always meet the monotonicity check.
+   (worklist items 16, 18) *)
+let align_by_labels_bidir ps1 ps2 =
+  let partner_in_ps2 a1 =
+    let hits =
+      List.mapi (fun j a2 -> (j, a2)) ps2
+      |> List.filter (fun (_, a2) -> labels_overlap a1 a2)
+    in
+    match hits with
+    | [] -> `None
+    | [ x ] -> `One x
+    | _ -> `Many
   in
-  loop short long_ 0
+  let rec walk_ps1 i = function
+    | [] -> Some []
+    | a1 :: t -> (
+        match partner_in_ps2 a1 with
+        | `Many -> None
+        | `None -> Option.map (fun r -> `Only (i, a1) :: r) (walk_ps1 (i + 1) t)
+        | `One (j, a2) ->
+            Option.map
+              (fun r -> `Match (i, j, a1, a2) :: r)
+              (walk_ps1 (i + 1) t))
+  in
+  match walk_ps1 0 ps1 with
+  | None -> None
+  | Some entries ->
+      let matches =
+        List.filter_map
+          (function
+            | `Match m -> Some m
+            | _ -> None)
+          entries
+      in
+      let ps1_only =
+        List.filter_map
+          (function
+            | `Only o -> Some o
+            | _ -> None)
+          entries
+      in
+      let matched_j = List.map (fun (_, j, _, _) -> j) matches in
+      let strictly_increasing =
+        matched_j = List.sort compare matched_j
+        && List.length matched_j
+           = List.length (List.sort_uniq compare matched_j)
+      in
+      if not strictly_increasing then None
+      else if matches = [] then
+        (* No shared arms: emitting retires for all of [ps1] and then adds
+           for all of [ps2] would transit through an empty (invalid)
+           parent. Bail to give-up; the caller's slot-level [Replace]
+           idiom builds [ps2]'s subtree alongside [ps1]'s and swaps
+           atomically. *)
+        None
+      else
+        let ps2_only =
+          List.mapi (fun j a -> (j, a)) ps2
+          |> List.filter (fun (j, _) -> not (List.mem j matched_j))
+        in
+        Some (matches, ps1_only, ps2_only)
 
 (* -------- sequence helpers ---------------------------------- *)
 
@@ -200,6 +241,60 @@ let is_replace_root = function
     ] -> true
   | _ -> false
 
+(* Shared emit for an [align_by_labels_bidir] result. Retires fire first
+   (descending [ps1]-frame index so lower-indexed slots don't shift while
+   higher retires are still pending), then adds (ascending [ps2]-frame
+   index; each add lands in the post-retire intermediate frame, which by
+   ascending construction equals the final ps2 frame as the adds rebuild
+   the structure), then per-match arm edits at their [ps2]-frame indices.
+   [slot_arm_edit] is the caller's per-slot edit closure (it recurses into
+   [analyze]); the unmetaed variant skips equal-arm matches outright, the
+   metaed variant emits a trailing [ChangeMeta] when the meta changed. *)
+let emit_bidir_unmetaed ~slot_arm_edit matches ps1_only ps2_only =
+  let descending = List.sort (fun (a, _) (b, _) -> compare b a) ps1_only in
+  let retire_steps =
+    List.concat_map (fun (i, _) -> prepend_seq i (retire ())) descending
+  in
+  let add_steps =
+    List.map
+      (fun (j, arm) -> (True, Delta.Add { path = [ j ]; arm; meta = None }))
+      ps2_only
+  in
+  let match_steps =
+    List.concat_map
+      (fun (_, j, arm1, arm2) ->
+        if arm1 = arm2 then [] else slot_arm_edit j arm1 arm2)
+      matches
+  in
+  retire_steps @ add_steps @ match_steps
+
+let emit_bidir_metaed ~slot_arm_edit ~ms1 ~ms2 matches ps1_only ps2_only =
+  let descending = List.sort (fun (a, _) (b, _) -> compare b a) ps1_only in
+  let retire_steps =
+    List.concat_map (fun (i, _) -> prepend_seq i (retire ())) descending
+  in
+  let add_steps =
+    List.map
+      (fun (j, arm) ->
+        (True, Delta.Add { path = [ j ]; arm; meta = Some (List.nth ms2 j) }))
+      ps2_only
+  in
+  let match_steps =
+    List.concat_map
+      (fun (i1, j2, arm1, arm2) ->
+        let m1 = List.nth ms1 i1 in
+        let m2 = List.nth ms2 j2 in
+        let meta = if m1 = m2 then None else Some m2 in
+        if arm1 = arm2 then
+          match meta with
+          | None -> []
+          | Some new_meta ->
+              [ (True, Delta.ChangeMeta { path = [ j2 ]; new_meta }) ]
+        else slot_arm_edit j2 arm1 arm2 ?meta ())
+      matches
+  in
+  retire_steps @ add_steps @ match_steps
+
 (* -------- sub-policy / sniffer ------------------------------ *)
 
 let rec is_sub_policy p1 p2 =
@@ -238,13 +333,27 @@ let rec compare_children ~next:p2 ps1 ps2 =
   in
   match List.compare_lengths ps1 ps2 with
   | 0 ->
-      (* Per-slot walk: each index whose arm differs contributes its own
-         independent edit. Distinct-index emissions concatenate freely. *)
-      List.concat
-        (List.mapi
-           (fun i (arm1, arm2) ->
-             if arm1 = arm2 then [] else slot_arm_edit i arm1 arm2)
-           (List.combine ps1 ps2))
+      (* Same-length fallback to bidirectional label-set alignment: when
+         [Pol.normalize] has reordered ps1 vs ps2 such that label-equivalent
+         arms now sit at different slot indices (e.g. an arm morphed past a
+         sibling in the sort), the per-slot walk would pair unrelated arms and
+         demote to [Replace]. Fire bidir whenever its alignment exhibits a
+         genuine cross-slot match ([i1 <> j2] for some match); when every
+         match aligns at the same slot, the per-slot walk is at least as
+         good and we let it run. (worklist item 20) *)
+      let per_slot () =
+        List.concat
+          (List.mapi
+             (fun i (arm1, arm2) ->
+               if arm1 = arm2 then [] else slot_arm_edit i arm1 arm2)
+             (List.combine ps1 ps2))
+      in
+      begin match align_by_labels_bidir ps1 ps2 with
+      | Some (matches, ps1_only, ps2_only)
+        when List.exists (fun (i1, j2, _, _) -> i1 <> j2) matches ->
+          emit_bidir_unmetaed ~slot_arm_edit matches ps1_only ps2_only
+      | _ -> per_slot ()
+      end
   | -1 ->
       (* Multi-arm add: every surplus entry in [ps2] is a pure addition (the
          arms of [ps1] appear in-order as a subsequence). One [Add] per extra
@@ -253,12 +362,10 @@ let rec compare_children ~next:p2 ps1 ps2 =
          indices in that frame).
 
          When the strict subsequence fails ([insertions] returns [None]) but
-         the divergence is "extra pure-add arms plus one or more shared arms
-         that morphed structurally", fall back to label-set alignment: pair
-         arms by overlapping class labels, recurse on each pair, and treat
-         unmatched [ps2] arms as pure adds (paper sketch.md sec5.2 case 8). The matched-
-         pair edits fire after the [Add]s have grown the structure, so their
-         slot indices are in [ps2]'s frame. *)
+         the divergence is "shared arms morphed structurally and/or some
+         [ps1] arm has no [ps2] partner", fall back to bidirectional
+         label-set alignment. The bidir emit may produce retires too (paper
+         sketch.md sec5.2 case 8; worklist item 16). *)
       begin match insertions ps1 ps2 with
       | Some adds ->
           List.map
@@ -266,22 +373,10 @@ let rec compare_children ~next:p2 ps1 ps2 =
               (True, Delta.Add { path = [ i ]; arm; meta = None }))
             adds
       | None -> (
-          match align_by_labels ps1 ps2 with
+          match align_by_labels_bidir ps1 ps2 with
           | None -> give_up
-          | Some (matches, adds) ->
-              let add_steps =
-                List.map
-                  (fun (i, arm) ->
-                    (True, Delta.Add { path = [ i ]; arm; meta = None }))
-                  adds
-              in
-              let match_steps =
-                List.concat_map
-                  (fun (i, arm1, arm2) ->
-                    if arm1 = arm2 then [] else slot_arm_edit i arm1 arm2)
-                  matches
-              in
-              add_steps @ match_steps)
+          | Some (matches, ps1_only, ps2_only) ->
+              emit_bidir_unmetaed ~slot_arm_edit matches ps1_only ps2_only)
       end
   | 1 ->
       (* Multi-arm retire: symmetric to the [-1] branch. Descending index
@@ -289,10 +384,10 @@ let rec compare_children ~next:p2 ps1 ps2 =
          still waiting to fire (mirrors [prune_down_to]'s within-level
          discipline).
 
-         Label-set fallback mirrors the [-1] case: when the strict
-         subsequence fails, pair arms by overlapping labels and recurse on
-         each pair. Retires fire first (descending [ps1]-frame indices),
-         then matched-pair edits in [ps2]'s post-retire frame. *)
+         Bidirectional fallback mirrors the [-1] case: when the strict
+         subsequence fails, [align_by_labels_bidir] can also discover
+         [ps2_only] arms (adds intermixed with the retires; worklist
+         item 16). *)
       begin match insertions ps2 ps1 with
       | Some retires ->
           let descending =
@@ -300,32 +395,10 @@ let rec compare_children ~next:p2 ps1 ps2 =
           in
           List.concat_map (fun (i, _) -> prepend_seq i (retire ())) descending
       | None -> (
-          match align_by_labels ps2 ps1 with
+          match align_by_labels_bidir ps1 ps2 with
           | None -> give_up
-          | Some (matches, retires) ->
-              let retire_indices = List.map fst retires in
-              let descending =
-                List.sort (fun (a, _) (b, _) -> compare b a) retires
-              in
-              let retire_steps =
-                List.concat_map
-                  (fun (i, _) -> prepend_seq i (retire ()))
-                  descending
-              in
-              let match_steps =
-                List.concat_map
-                  (fun (ps1_idx, ps2_arm, ps1_arm) ->
-                    if ps1_arm = ps2_arm then []
-                    else
-                      let ps2_idx =
-                        ps1_idx
-                        - List.length
-                            (List.filter (fun k -> k < ps1_idx) retire_indices)
-                      in
-                      slot_arm_edit ps2_idx ps1_arm ps2_arm)
-                  matches
-              in
-              retire_steps @ match_steps)
+          | Some (matches, ps1_only, ps2_only) ->
+              emit_bidir_unmetaed ~slot_arm_edit matches ps1_only ps2_only)
       end
   | _ -> failwith "Can't get here"
 
@@ -371,21 +444,60 @@ and compare_metaed_children ~next:p2 pms1 pms2 =
   in
   match List.compare_lengths ps1 ps2 with
   | 0 ->
-      (* Per-slot walk: each index whose arm or meta differs contributes its
-         own independent edit. *)
-      let triples =
-        List.combine (List.combine ps1 ms1) (List.combine ps2 ms2)
-      in
-      List.concat
-        (List.mapi
-           (fun i ((arm1, m1), (arm2, m2)) ->
-             match (arm1 <> arm2, m1 <> m2) with
-             | false, false -> []
-             | false, true ->
-                 [ (True, Delta.ChangeMeta { path = [ i ]; new_meta = m2 }) ]
-             | true, false -> slot_arm_edit i arm1 arm2 ()
-             | true, true -> slot_arm_edit i arm1 arm2 ~meta:m2 ())
-           triples)
+      (* Pre-pass: if [ps1] and [ps2] hold the same arm contents in
+         different positions, the difference is purely a meta shuffle that
+         [Pol.normalize]'s rank sort exposed (e.g.
+         [SP((A,1),(B,2)) -> SP((B,1),(A,2))]). Emit one [ChangeMeta] per
+         slot whose meta needs to move, rather than per-slot [Replace]s
+         between unrelated arms. The new meta for [ps1]'s slot [i] is
+         [ps2]'s meta at whichever slot hosts the same arm; leaf-partition
+         validity (sec3.2) guarantees a unique match. After the sequence
+         fires, [Pol.normalize] re-sorts the rebalanced policy into [ps2]'s
+         shape. (worklist item 17) *)
+      let arms_only = List.sort compare in
+      if ps1 <> ps2 && arms_only ps1 = arms_only ps2 then
+        let indexed_ps2 = List.mapi (fun j a -> (j, a)) ps2 in
+        List.concat
+          (List.mapi
+             (fun i arm1 ->
+               let j, _ = List.find (fun (_, a) -> a = arm1) indexed_ps2 in
+               let new_meta = List.nth ms2 j in
+               if List.nth ms1 i = new_meta then []
+               else [ (True, Delta.ChangeMeta { path = [ i ]; new_meta }) ])
+             ps1)
+      else
+        (* Per-slot walk: each index whose arm or meta differs contributes
+           its own independent edit. Same-length bidirectional fallback runs
+           first: when [Pol.normalize]'s sort has placed label-equivalent
+           arms at different slot indices in ps1 vs ps2 (e.g. an SP rank
+           change crossing a co-changing arm morph), the per-slot walk would
+           pair unrelated arms and emit slot-level [Replace]s. Fire bidir
+           whenever its alignment exhibits a genuine cross-slot match
+           ([i1 <> j2] for some match); otherwise the per-slot walk is at
+           least as good and runs. (worklist item 20) *)
+        let per_slot () =
+          let triples =
+            List.combine (List.combine ps1 ms1) (List.combine ps2 ms2)
+          in
+          List.concat
+            (List.mapi
+               (fun i ((arm1, m1), (arm2, m2)) ->
+                 match (arm1 <> arm2, m1 <> m2) with
+                 | false, false -> []
+                 | false, true ->
+                     [
+                       (True, Delta.ChangeMeta { path = [ i ]; new_meta = m2 });
+                     ]
+                 | true, false -> slot_arm_edit i arm1 arm2 ()
+                 | true, true -> slot_arm_edit i arm1 arm2 ~meta:m2 ())
+               triples)
+        in
+        begin match align_by_labels_bidir ps1 ps2 with
+        | Some (matches, ps1_only, ps2_only)
+          when List.exists (fun (i1, j2, _, _) -> i1 <> j2) matches ->
+            emit_bidir_metaed ~slot_arm_edit ~ms1 ~ms2 matches ps1_only ps2_only
+        | _ -> per_slot ()
+        end
   | -1 ->
       (* [ps1] must embed in [ps2] as a subsequence. Each surplus [ps2] arm
          becomes an [Add] carrying that arm's meta; each [ps2] index whose
@@ -393,15 +505,10 @@ and compare_metaed_children ~next:p2 pms1 pms2 =
          differ. All [Add]s fire first, in ascending [ps2]-index order, so
          each trailing [ChangeMeta]'s path lands in [ps2]'s frame.
 
-         When the strict subsequence fails ([insertions] returns [None]) but
-         the divergence is "extra pure-add arms plus one or more shared arms
-         that morphed structurally", fall back to label-set alignment (the
-         metaed analogue of [compare_children]'s fallback, paper sketch.md
-         sec5.2 case 8): pair arms by overlapping class labels, recurse
-         on each pair via [slot_arm_edit] carrying any meta change, and treat
-         unmatched [ps2] arms as pure [Add]s with their meta. The [i1] index
-         on the [ps1] side is the position in [matches] because the greedy
-         walk consumes [ps1] left-to-right. *)
+         When the strict subsequence fails ([insertions] returns [None]),
+         fall back to bidirectional label-set alignment. As in
+         [compare_children], the bidir emit may also produce retires for
+         [ps1_only] arms (worklist item 16). *)
       begin match insertions ps1 ps2 with
       | Some adds ->
           let add_indices = List.map fst adds in
@@ -430,38 +537,21 @@ and compare_metaed_children ~next:p2 pms1 pms2 =
           in
           add_steps @ change_meta_steps
       | None -> (
-          match align_by_labels ps1 ps2 with
+          match align_by_labels_bidir ps1 ps2 with
           | None -> give_up
-          | Some (matches, adds) ->
-              let add_steps =
-                List.map
-                  (fun (j, arm) ->
-                    ( True,
-                      Delta.Add
-                        { path = [ j ]; arm; meta = Some (List.nth ms2 j) } ))
-                  adds
-              in
-              let match_steps =
-                List.concat
-                  (List.mapi
-                     (fun i1 (j, arm1, arm2) ->
-                       let m1 = List.nth ms1 i1 in
-                       let m2 = List.nth ms2 j in
-                       let meta = if m1 = m2 then None else Some m2 in
-                       slot_arm_edit j arm1 arm2 ?meta ())
-                     matches)
-              in
-              add_steps @ match_steps)
+          | Some (matches, ps1_only, ps2_only) ->
+              emit_bidir_metaed ~slot_arm_edit ~ms1 ~ms2 matches ps1_only
+                ps2_only)
       end
   | 1 ->
       (* Symmetric to [-1]: surplus [ps1] arms retire (descending so
          lower-index paths stay stable); shared arms whose metas differ
          take a [ChangeMeta] in [ps2]'s post-Retire frame.
 
-         Label-set fallback mirrors the [-1] case: pair arms by overlapping
-         labels and recurse via [slot_arm_edit]. Retires fire first
-         (descending [ps1]-frame indices), then matched-pair edits at the
-         [ps2]-frame index [ps1_idx - count_of_retires_below]. *)
+         Bidirectional fallback mirrors the [-1] case: when the strict
+         subsequence fails, [align_by_labels_bidir] can also discover
+         [ps2_only] arms (adds intermixed with the retires; worklist
+         item 16). *)
       begin match insertions ps2 ps1 with
       | Some retires ->
           let retire_indices = List.map fst retires in
@@ -488,34 +578,11 @@ and compare_metaed_children ~next:p2 pms1 pms2 =
           in
           retire_steps @ change_meta_steps
       | None -> (
-          match align_by_labels ps2 ps1 with
+          match align_by_labels_bidir ps1 ps2 with
           | None -> give_up
-          | Some (matches, retires) ->
-              let retire_indices = List.map fst retires in
-              let descending =
-                List.sort (fun (a, _) (b, _) -> compare b a) retires
-              in
-              let retire_steps =
-                List.concat_map
-                  (fun (i, _) -> prepend_seq i (retire ()))
-                  descending
-              in
-              let match_steps =
-                List.concat
-                  (List.mapi
-                     (fun i2 (ps1_idx, ps2_arm, ps1_arm) ->
-                       let m1 = List.nth ms1 ps1_idx in
-                       let m2 = List.nth ms2 i2 in
-                       let meta = if m1 = m2 then None else Some m2 in
-                       let ps2_idx =
-                         ps1_idx
-                         - List.length
-                             (List.filter (fun k -> k < ps1_idx) retire_indices)
-                       in
-                       slot_arm_edit ps2_idx ps1_arm ps2_arm ?meta ())
-                     matches)
-              in
-              retire_steps @ match_steps)
+          | Some (matches, ps1_only, ps2_only) ->
+              emit_bidir_metaed ~slot_arm_edit ~ms1 ~ms2 matches ps1_only
+                ps2_only)
       end
   | _ -> failwith "Can't get here"
 

--- a/rio/planner/planner.ml
+++ b/rio/planner/planner.ml
@@ -38,7 +38,7 @@ let insertions prev next =
    well-formed policy keeps these distinct across arms; the planner's
    [compare_children] fallback below treats label overlap between two arms
    as evidence that they denote the same flow that morphed structurally
-   (paper many-arms.md). *)
+   (paper sketch.md sec5.2 case 8, sec3.2 leaf-partition validity). *)
 let rec arm_labels = function
   | FIFO c -> [ c ]
   | SP (prs, _) | WFQ prs -> List.concat_map (fun (p, _) -> arm_labels p) prs
@@ -256,7 +256,7 @@ let rec compare_children ~next:p2 ps1 ps2 =
          the divergence is "extra pure-add arms plus one or more shared arms
          that morphed structurally", fall back to label-set alignment: pair
          arms by overlapping class labels, recurse on each pair, and treat
-         unmatched [ps2] arms as pure adds (paper many-arms.md). The matched-
+         unmatched [ps2] arms as pure adds (paper sketch.md sec5.2 case 8). The matched-
          pair edits fire after the [Add]s have grown the structure, so their
          slot indices are in [ps2]'s frame. *)
       begin match insertions ps1 ps2 with
@@ -396,8 +396,8 @@ and compare_metaed_children ~next:p2 pms1 pms2 =
          When the strict subsequence fails ([insertions] returns [None]) but
          the divergence is "extra pure-add arms plus one or more shared arms
          that morphed structurally", fall back to label-set alignment (the
-         metaed analogue of [compare_children]'s fallback, paper many-arms.md
-         and sketch.md §5.4): pair arms by overlapping class labels, recurse
+         metaed analogue of [compare_children]'s fallback, paper sketch.md
+         sec5.2 case 8): pair arms by overlapping class labels, recurse
          on each pair via [slot_arm_edit] carrying any meta change, and treat
          unmatched [ps2] arms as pure [Add]s with their meta. The [i1] index
          on the [ps1] side is the position in [matches] because the greedy

--- a/rio/planner/planner.ml
+++ b/rio/planner/planner.ml
@@ -33,6 +33,56 @@ let insertions prev next =
   in
   loop 0 prev next []
 
+(* The set of class labels reachable from a policy: each [FIFO] leaf
+   contributes its class; SP/WFQ/RR fold up their children's labels. A
+   well-formed policy keeps these distinct across arms; the planner's
+   [compare_children] fallback below treats label overlap between two arms
+   as evidence that they denote the same flow that morphed structurally
+   (paper many-arms.md). *)
+let rec arm_labels = function
+  | FIFO c -> [ c ]
+  | SP (prs, _) | WFQ prs -> List.concat_map (fun (p, _) -> arm_labels p) prs
+  | RR ps -> List.concat_map arm_labels ps
+
+let labels_overlap a b =
+  let lb = arm_labels b in
+  List.exists (fun x -> List.mem x lb) (arm_labels a)
+
+(* Greedy label-set alignment for [compare_children]'s length-differing
+   branches: when [insertions] fails because a matched arm has morphed
+   (lengths differ AND a shared arm changed structurally), line up [short]
+   inside [long] by overlapping label sets instead of by structural
+   equality. Walks both lists once: pairs the heads if their label sets
+   overlap, otherwise consumes the long head as a pure surplus (an [Add] in
+   the [-1] branch, a [Retire] in the [1] branch). If [short] still has
+   arms after [long] is exhausted, no alignment was found; the caller falls
+   through to give-up. Returns [(matches, surplus)] where each match is
+   [(long_idx, short_arm, long_arm)] in [long]'s frame and each surplus is
+   [(long_idx, long_arm)]. Greedy left-to-right; suffices for the cases
+   currently in the test suite, and the cost-model question of which
+   alignment to prefer when several are admissible is parked in
+   [paper/sketch.md] §5.4. *)
+let align_by_labels short long_ =
+  let rec loop short long_ i =
+    match (short, long_) with
+    | [], [] -> Some ([], [])
+    | [], r :: rt ->
+        Option.map
+          (fun (matches, surplus) -> (matches, (i, r) :: surplus))
+          (loop [] rt (i + 1))
+    | _ :: _, [] -> None
+    | l :: lt, r :: rt ->
+        if labels_overlap l r then
+          Option.map
+            (fun (matches, surplus) -> ((i, l, r) :: matches, surplus))
+            (loop lt rt (i + 1))
+        else
+          Option.map
+            (fun (matches, surplus) -> (matches, (i, r) :: surplus))
+            (loop short rt (i + 1))
+  in
+  loop short long_ 0
+
 (* -------- sequence helpers ---------------------------------- *)
 
 let prepend_guard i = function
@@ -198,27 +248,82 @@ let rec compare_children ~next:p2 ps1 ps2 =
          arms of [ps1] appear in-order as a subsequence). One [Add] per extra
          in ascending index order; each subsequent path is into the structure
          as the earlier [Add]s grew it (and [insertions] already returns
-         indices in that frame). *)
+         indices in that frame).
+
+         When the strict subsequence fails ([insertions] returns [None]) but
+         the divergence is "extra pure-add arms plus one or more shared arms
+         that morphed structurally", fall back to label-set alignment: pair
+         arms by overlapping class labels, recurse on each pair, and treat
+         unmatched [ps2] arms as pure adds (paper many-arms.md). The matched-
+         pair edits fire after the [Add]s have grown the structure, so their
+         slot indices are in [ps2]'s frame. *)
       begin match insertions ps1 ps2 with
       | Some adds ->
           List.map
             (fun (i, arm) ->
               (True, Delta.Add { path = [ i ]; arm; meta = None }))
             adds
-      | None -> give_up
+      | None -> (
+          match align_by_labels ps1 ps2 with
+          | None -> give_up
+          | Some (matches, adds) ->
+              let add_steps =
+                List.map
+                  (fun (i, arm) ->
+                    (True, Delta.Add { path = [ i ]; arm; meta = None }))
+                  adds
+              in
+              let match_steps =
+                List.concat_map
+                  (fun (i, arm1, arm2) ->
+                    if arm1 = arm2 then [] else slot_arm_edit i arm1 arm2)
+                  matches
+              in
+              add_steps @ match_steps)
       end
   | 1 ->
       (* Multi-arm retire: symmetric to the [-1] branch. Descending index
          order so retiring a higher slot doesn't shift the lower-index paths
          still waiting to fire (mirrors [prune_down_to]'s within-level
-         discipline). *)
+         discipline).
+
+         Label-set fallback mirrors the [-1] case: when the strict
+         subsequence fails, pair arms by overlapping labels and recurse on
+         each pair. Retires fire first (descending [ps1]-frame indices),
+         then matched-pair edits in [ps2]'s post-retire frame. *)
       begin match insertions ps2 ps1 with
       | Some retires ->
           let descending =
             List.sort (fun (a, _) (b, _) -> compare b a) retires
           in
           List.concat_map (fun (i, _) -> prepend_seq i (retire ())) descending
-      | None -> give_up
+      | None -> (
+          match align_by_labels ps2 ps1 with
+          | None -> give_up
+          | Some (matches, retires) ->
+              let retire_indices = List.map fst retires in
+              let descending =
+                List.sort (fun (a, _) (b, _) -> compare b a) retires
+              in
+              let retire_steps =
+                List.concat_map
+                  (fun (i, _) -> prepend_seq i (retire ()))
+                  descending
+              in
+              let match_steps =
+                List.concat_map
+                  (fun (ps1_idx, ps2_arm, ps1_arm) ->
+                    if ps1_arm = ps2_arm then []
+                    else
+                      let ps2_idx =
+                        ps1_idx
+                        - List.length
+                            (List.filter (fun k -> k < ps1_idx) retire_indices)
+                      in
+                      slot_arm_edit ps2_idx ps1_arm ps2_arm)
+                  matches
+              in
+              retire_steps @ match_steps)
       end
   | _ -> failwith "Can't get here"
 

--- a/rio/planner/planner.ml
+++ b/rio/planner/planner.ml
@@ -48,7 +48,7 @@ let labels_overlap a b =
   let lb = arm_labels b in
   List.exists (fun x -> List.mem x lb) (arm_labels a)
 
-(* Greedy label-set alignment for [compare_children]'s length-differing
+(* Greedy label-set alignment for the comparators' length-differing
    branches: when [insertions] fails because a matched arm has morphed
    (lengths differ AND a shared arm changed structurally), line up [short]
    inside [long] by overlapping label sets instead of by structural
@@ -58,9 +58,11 @@ let labels_overlap a b =
    arms after [long] is exhausted, no alignment was found; the caller falls
    through to give-up. Returns [(matches, surplus)] where each match is
    [(long_idx, short_arm, long_arm)] in [long]'s frame and each surplus is
-   [(long_idx, long_arm)]. Greedy left-to-right; suffices for the cases
-   currently in the test suite, and the cost-model question of which
-   alignment to prefer when several are admissible is parked in
+   [(long_idx, long_arm)]. Both [compare_children] (RR) and
+   [compare_metaed_children] (SP/WFQ) use this fallback; the metaed callers
+   read the meta off [ms1]/[ms2] by position. Greedy left-to-right; suffices
+   for the cases currently in the test suite, and the cost-model question
+   of which alignment to prefer when several are admissible is parked in
    [paper/sketch.md] §5.4. *)
 let align_by_labels short long_ =
   let rec loop short long_ i =
@@ -389,9 +391,18 @@ and compare_metaed_children ~next:p2 pms1 pms2 =
          becomes an [Add] carrying that arm's meta; each [ps2] index whose
          arm came from [ps1] contributes a [ChangeMeta] when the metas
          differ. All [Add]s fire first, in ascending [ps2]-index order, so
-         each trailing [ChangeMeta]'s path lands in [ps2]'s frame. *)
+         each trailing [ChangeMeta]'s path lands in [ps2]'s frame.
+
+         When the strict subsequence fails ([insertions] returns [None]) but
+         the divergence is "extra pure-add arms plus one or more shared arms
+         that morphed structurally", fall back to label-set alignment (the
+         metaed analogue of [compare_children]'s fallback, paper many-arms.md
+         and sketch.md §5.4): pair arms by overlapping class labels, recurse
+         on each pair via [slot_arm_edit] carrying any meta change, and treat
+         unmatched [ps2] arms as pure [Add]s with their meta. The [i1] index
+         on the [ps1] side is the position in [matches] because the greedy
+         walk consumes [ps1] left-to-right. *)
       begin match insertions ps1 ps2 with
-      | None -> give_up
       | Some adds ->
           let add_indices = List.map fst adds in
           let add_steps =
@@ -418,13 +429,40 @@ and compare_metaed_children ~next:p2 pms1 pms2 =
               (List.init (List.length ps2) (fun j -> j))
           in
           add_steps @ change_meta_steps
+      | None -> (
+          match align_by_labels ps1 ps2 with
+          | None -> give_up
+          | Some (matches, adds) ->
+              let add_steps =
+                List.map
+                  (fun (j, arm) ->
+                    ( True,
+                      Delta.Add
+                        { path = [ j ]; arm; meta = Some (List.nth ms2 j) } ))
+                  adds
+              in
+              let match_steps =
+                List.concat
+                  (List.mapi
+                     (fun i1 (j, arm1, arm2) ->
+                       let m1 = List.nth ms1 i1 in
+                       let m2 = List.nth ms2 j in
+                       let meta = if m1 = m2 then None else Some m2 in
+                       slot_arm_edit j arm1 arm2 ?meta ())
+                     matches)
+              in
+              add_steps @ match_steps)
       end
   | 1 ->
       (* Symmetric to [-1]: surplus [ps1] arms retire (descending so
          lower-index paths stay stable); shared arms whose metas differ
-         take a [ChangeMeta] in [ps2]'s post-Retire frame. *)
+         take a [ChangeMeta] in [ps2]'s post-Retire frame.
+
+         Label-set fallback mirrors the [-1] case: pair arms by overlapping
+         labels and recurse via [slot_arm_edit]. Retires fire first
+         (descending [ps1]-frame indices), then matched-pair edits at the
+         [ps2]-frame index [ps1_idx - count_of_retires_below]. *)
       begin match insertions ps2 ps1 with
-      | None -> give_up
       | Some retires ->
           let retire_indices = List.map fst retires in
           let descending =
@@ -449,6 +487,35 @@ and compare_metaed_children ~next:p2 pms1 pms2 =
               (List.mapi (fun j i1 -> (j, i1)) ps1_matched)
           in
           retire_steps @ change_meta_steps
+      | None -> (
+          match align_by_labels ps2 ps1 with
+          | None -> give_up
+          | Some (matches, retires) ->
+              let retire_indices = List.map fst retires in
+              let descending =
+                List.sort (fun (a, _) (b, _) -> compare b a) retires
+              in
+              let retire_steps =
+                List.concat_map
+                  (fun (i, _) -> prepend_seq i (retire ()))
+                  descending
+              in
+              let match_steps =
+                List.concat
+                  (List.mapi
+                     (fun i2 (ps1_idx, ps2_arm, ps1_arm) ->
+                       let m1 = List.nth ms1 ps1_idx in
+                       let m2 = List.nth ms2 i2 in
+                       let meta = if m1 = m2 then None else Some m2 in
+                       let ps2_idx =
+                         ps1_idx
+                         - List.length
+                             (List.filter (fun k -> k < ps1_idx) retire_indices)
+                       in
+                       slot_arm_edit ps2_idx ps1_arm ps2_arm ?meta ())
+                     matches)
+              in
+              retire_steps @ match_steps)
       end
   | _ -> failwith "Can't get here"
 

--- a/rio/tests/planner/test_planner.ml
+++ b/rio/tests/planner/test_planner.ml
@@ -335,8 +335,8 @@ let add_with_shared_meta_change =
    alignment: arms whose class-label sets overlap are paired (and recursed
    on); arms whose labels appear nowhere on the other side are treated as
    pure [Add]s (or [Retire]s, symmetrically). Under the "repeated labels =
-   same flow" assumption (paper many-arms.md), the alignment in these
-   examples is unambiguous. *)
+   same flow" assumption (paper sketch.md sec3.2 leaf-partition validity),
+   the alignment in these examples is unambiguous. *)
 let aligned_multi =
   [
     (* rr_A_strictBCD normalizes to RR[FIFO A, SP[B,C,D]]; rr_A_strictBC_E

--- a/rio/tests/planner/test_planner.ml
+++ b/rio/tests/planner/test_planner.ml
@@ -364,6 +364,51 @@ let aligned_multi =
         ( Planner.True,
           Delta.Add { path = [ 1; 2 ]; arm = Pol.FIFO "D"; meta = Some 3.0 } );
       ];
+    (* SP-side analogue (outer is SP, inner is RR). sp_A_rrBCD normalizes to
+       SP[(A, 1); (RR[B,C,D], 2)]; sp_A_rrBC_E to SP[(A, 1); (RR[B,C], 2);
+       (E, 3)]. Label-set alignment pairs the RRs (via {B,C} overlap) and
+       treats E as a pure Add at ps2 index 2 carrying its rank meta. The
+       matched-pair edit recurses into the inner RR and retires D. *)
+    make_planner_test "SP adds a sibling while an inner RR retires" "sp_A_rrBCD"
+      "sp_A_rrBC_E"
+      [
+        ( Planner.True,
+          Delta.Add { path = [ 2 ]; arm = Pol.FIFO "E"; meta = Some 3.0 } );
+        (Planner.True, Delta.Quiesce [ 1; 2 ]);
+        (Planner.Empty [ 1; 2 ], Delta.Remove [ 1; 2 ]);
+      ];
+    make_planner_test "SP retires a sibling while an inner RR adds"
+      "sp_A_rrBC_E" "sp_A_rrBCD"
+      [
+        (Planner.True, Delta.Quiesce [ 2 ]);
+        (Planner.Empty [ 2 ], Delta.Remove [ 2 ]);
+        ( Planner.True,
+          Delta.Add { path = [ 1; 2 ]; arm = Pol.FIFO "D"; meta = None } );
+      ];
+    (* WFQ-side analogue. WFQ normalize sorts children by arm content first
+       (FIFO < RR by polymorphic compare; among FIFOs, A < E
+       alphabetically), so wfq_A_rrBCD normalizes to WFQ[(A, 1); (RR[B,C,D],
+       2)] but wfq_A_rrBC_E normalizes to WFQ[(A, 1); (E, 3); (RR[B,C], 2)].
+       Label-set alignment pairs A with A and the RRs with each other,
+       inserting E between them as a non-contiguous Add at ps2 index 1; the
+       RR match lands at ps2 index 2 in the post-Add frame and recurses to
+       retire D inside. *)
+    make_planner_test "WFQ adds a sibling while an inner RR retires"
+      "wfq_A_rrBCD" "wfq_A_rrBC_E"
+      [
+        ( Planner.True,
+          Delta.Add { path = [ 1 ]; arm = Pol.FIFO "E"; meta = Some 3.0 } );
+        (Planner.True, Delta.Quiesce [ 2; 2 ]);
+        (Planner.Empty [ 2; 2 ], Delta.Remove [ 2; 2 ]);
+      ];
+    make_planner_test "WFQ retires a sibling while an inner RR adds"
+      "wfq_A_rrBC_E" "wfq_A_rrBCD"
+      [
+        (Planner.True, Delta.Quiesce [ 1 ]);
+        (Planner.Empty [ 1 ], Delta.Remove [ 1 ]);
+        ( Planner.True,
+          Delta.Add { path = [ 1; 2 ]; arm = Pol.FIFO "D"; meta = None } );
+      ];
   ]
 
 let nested_giveup_demotion =

--- a/rio/tests/planner/test_planner.ml
+++ b/rio/tests/planner/test_planner.ml
@@ -329,6 +329,43 @@ let add_with_shared_meta_change =
       ];
   ]
 
+(* Length-changing RR parent where one of the shared arms is itself morphed
+   structurally rather than equal. When [insertions] fails because the
+   matched arms aren't strictly equal, the planner falls back to label-set
+   alignment: arms whose class-label sets overlap are paired (and recursed
+   on); arms whose labels appear nowhere on the other side are treated as
+   pure [Add]s (or [Retire]s, symmetrically). Under the "repeated labels =
+   same flow" assumption (paper many-arms.md), the alignment in these
+   examples is unambiguous. *)
+let aligned_multi =
+  [
+    (* rr_A_strictBCD normalizes to RR[FIFO A, SP[B,C,D]]; rr_A_strictBC_E
+       to RR[FIFO A, FIFO E, SP[B,C]]. [insertions] fails because SP[B,C,D]
+       and SP[B,C] aren't equal. Label-set alignment pairs the SPs (via
+       {B,C} overlap) and treats E as a pure Add at ps2 index 1. After the
+       Add fires, the SP slot lives at ps2 index 2; the recursive analyze
+       there is a [Retire] of D inside the SP. *)
+    make_planner_test "RR adds a sibling while an inner SP retires"
+      "rr_A_strictBCD" "rr_A_strictBC_E"
+      [
+        ( Planner.True,
+          Delta.Add { path = [ 1 ]; arm = Pol.FIFO "E"; meta = None } );
+        (Planner.True, Delta.Quiesce [ 2; 2 ]);
+        (Planner.Empty [ 2; 2 ], Delta.Remove [ 2; 2 ]);
+      ];
+    (* Reverse direction: ps1 longer. [E] is a pure retire at ps1 index 1;
+       the SP slot at ps1 index 2 lands at ps2 index 1 after the retire, and
+       the inner analyze is an [Add] of D inside the SP with weight 3. *)
+    make_planner_test "RR retires a sibling while an inner SP adds"
+      "rr_A_strictBC_E" "rr_A_strictBCD"
+      [
+        (Planner.True, Delta.Quiesce [ 1 ]);
+        (Planner.Empty [ 1 ], Delta.Remove [ 1 ]);
+        ( Planner.True,
+          Delta.Add { path = [ 1; 2 ]; arm = Pol.FIFO "D"; meta = Some 3.0 } );
+      ];
+  ]
+
 let nested_giveup_demotion =
   [
     make_planner_test "nested Graft demotes to give-up" "strict_AB"
@@ -382,7 +419,7 @@ let suite =
        @ multi_arms_removed @ multi_arms_added_metaed
        @ multi_arms_removed_metaed @ metachanged @ one_arm_replaced
        @ one_arm_replaced_wfq @ multi_arms_replaced @ multi_arms_replaced_metaed
-       @ add_with_shared_meta_change @ verydiff_combos @ graft @ change_root
-       @ nested_giveup_demotion
+       @ add_with_shared_meta_change @ aligned_multi @ verydiff_combos @ graft
+       @ change_root @ nested_giveup_demotion
 
 let () = run_test_tt_main suite

--- a/rio/tests/planner/test_planner.ml
+++ b/rio/tests/planner/test_planner.ml
@@ -292,16 +292,28 @@ let multi_arms_replaced_metaed =
       @ replace_seq ~meta:2.0 [ 1 ] (Pol.FIFO "E")
       @ replace_seq [ 2 ] (Pol.FIFO "F"));
     (* SP rank swap: strict_AB = (A,1),(B,2); strict_BA = (B,1),(A,2).
-       After [Pol.normalize]'s rank sort the two arms appear in swapped
-       slots with the original ranks unchanged. *)
+       After [Pol.normalize]'s rank sort the two arms sit in the same slots
+       carrying the original ranks; the difference is that A's new rank is
+       2 and B's new rank is 1. [compare_metaed_children]'s permutation
+       pre-pass detects that the arm contents are a permutation of each
+       other and emits one [ChangeMeta] per slot. (worklist item 17) *)
     make_planner_test "Strict with arms reordered" "strict_AB" "strict_BA"
-      (replace_seq [ 0 ] (Pol.FIFO "B") @ replace_seq [ 1 ] (Pol.FIFO "A"));
-    (* complex_tree's outer slot 0 differs (strict[A,B,C] vs strict[C,B,A])
-       and the inner recursion itself returns a multi-slot Replace; the
-       outer edit bubbles that inner sequence via [prepend_seq 0]. *)
+      [
+        (Planner.True, Delta.ChangeMeta { path = [ 0 ]; new_meta = 2.0 });
+        (Planner.True, Delta.ChangeMeta { path = [ 1 ]; new_meta = 1.0 });
+      ];
+    (* complex_tree's outer slot 0 has an inner SP that's an arm permutation
+       (strict[A,B,C] vs strict[C,B,A], same ranks [1;2;3]). Permutation
+       pre-pass at the inner level emits ChangeMetas: slot 0 (arm A) takes
+       A's new rank 3; slot 1 (arm B) is a fixed point and skips; slot 2
+       (arm C) takes C's new rank 1. The inner sequence bubbles via
+       [prepend_seq 0]. *)
     make_planner_test "complex tree with an SP reordering deep down"
       "complex_tree" "complex_tree_swap_sp_arms"
-      (replace_seq [ 0; 0 ] (Pol.FIFO "C") @ replace_seq [ 0; 2 ] (Pol.FIFO "A"));
+      [
+        (Planner.True, Delta.ChangeMeta { path = [ 0; 0 ]; new_meta = 3.0 });
+        (Planner.True, Delta.ChangeMeta { path = [ 0; 2 ]; new_meta = 1.0 });
+      ];
     (* wfq_complex's slot 1 has both a deeper arm change (inner RR replaces
        a leaf) and a weight change. The inner sequence is itself a bubbled
        Replace, so the slot's edit becomes (bubbled inner) ++ ChangeMeta. *)
@@ -411,6 +423,75 @@ let aligned_multi =
       ];
   ]
 
+(* Bidirectional label-set alignment at a single parent: some [ps1] arms
+   retire (their labels appear nowhere in [ps2]) and some [ps2] arms add
+   (their labels appear nowhere in [ps1]), while one or more shared arms
+   anchor the alignment. Symmetric across the |-1| and |+1| length branches
+   and across RR vs. metaed (SP/WFQ) parents. The [matches = []] guard in
+   [align_by_labels_bidir] keeps the wholesale-divergence case
+   ([rr_AB -> rr_DEF]) on the give-up path so the intermediate parent never
+   empties out. (worklist item 16) *)
+let mixed_add_retire =
+  [
+    make_planner_test "RR retires one arm and adds two" "rr_AB" "rr_ACD"
+      (retire_seq [ 1 ]
+      @ [
+          ( Planner.True,
+            Delta.Add { path = [ 1 ]; arm = Pol.FIFO "C"; meta = None } );
+          ( Planner.True,
+            Delta.Add { path = [ 2 ]; arm = Pol.FIFO "D"; meta = None } );
+        ]);
+    make_planner_test "RR retires two arms and adds one" "rr_ACD" "rr_AB"
+      (retire_seq [ 2 ] @ retire_seq [ 1 ]
+      @ [
+          ( Planner.True,
+            Delta.Add { path = [ 1 ]; arm = Pol.FIFO "B"; meta = None } );
+        ]);
+    make_planner_test "SP retires one arm and adds two with ranks" "strict_AB"
+      "strict_ACD"
+      (retire_seq [ 1 ]
+      @ [
+          ( Planner.True,
+            Delta.Add { path = [ 1 ]; arm = Pol.FIFO "C"; meta = Some 2.0 } );
+          ( Planner.True,
+            Delta.Add { path = [ 2 ]; arm = Pol.FIFO "D"; meta = Some 3.0 } );
+        ]);
+    make_planner_test "SP retires two arms and adds one with rank" "strict_ACD"
+      "strict_AB"
+      (retire_seq [ 2 ] @ retire_seq [ 1 ]
+      @ [
+          ( Planner.True,
+            Delta.Add { path = [ 1 ]; arm = Pol.FIFO "B"; meta = Some 2.0 } );
+        ]);
+  ]
+
+(* Same-length parents whose label-set alignment crosses slot indices
+   ([i1 <> j2] for some match): the per-slot walk would pair unrelated arms
+   and demote each divergent slot to [Replace], but bidirectional alignment
+   recovers the real correspondence via class-label overlap. Triggered only
+   when the bidir match set is non-trivially cross-slot; otherwise the
+   per-slot walk is preserved. (worklist item 20) *)
+let same_length_bidir =
+  [
+    (* wfq_ABC normalizes to WFQ[(A, 2); (B, 1); (C, 3)]; wfq_Z_rrAY_rrCW
+       to WFQ[(Z, 4); (RR[A, Y], 7); (RR[C, W], 8)]. Both length 3, neither
+       arm-multiset nor per-slot equal, so the permutation pre-pass doesn't
+       fire and the per-slot walk would emit three Replaces. Bidir aligns
+       A -> RR[A, Y] at ps2 slot 1 and C -> RR[C, W] at ps2 slot 2 by label
+       overlap; B has no partner in ps2 (retire) and Z has no partner in
+       ps1 (Add). The first match's i1=0, j2=1 trips the cross-slot
+       trigger. *)
+    make_planner_test "WFQ same-length cross-slot morph" "wfq_ABC"
+      "wfq_Z_rrAY_rrCW"
+      (retire_seq [ 1 ]
+      @ [
+          ( Planner.True,
+            Delta.Add { path = [ 0 ]; arm = Pol.FIFO "Z"; meta = Some 4.0 } );
+        ]
+      @ replace_seq ~meta:7.0 [ 1 ] (Pol.RR [ Pol.FIFO "A"; Pol.FIFO "Y" ])
+      @ replace_seq ~meta:8.0 [ 2 ] (Pol.RR [ Pol.FIFO "C"; Pol.FIFO "W" ]));
+  ]
+
 let nested_giveup_demotion =
   [
     make_planner_test "nested Graft demotes to give-up" "strict_AB"
@@ -464,7 +545,8 @@ let suite =
        @ multi_arms_removed @ multi_arms_added_metaed
        @ multi_arms_removed_metaed @ metachanged @ one_arm_replaced
        @ one_arm_replaced_wfq @ multi_arms_replaced @ multi_arms_replaced_metaed
-       @ add_with_shared_meta_change @ aligned_multi @ verydiff_combos @ graft
-       @ change_root @ nested_giveup_demotion
+       @ add_with_shared_meta_change @ aligned_multi @ mixed_add_retire
+       @ same_length_bidir @ verydiff_combos @ graft @ change_root
+       @ nested_giveup_demotion
 
 let () = run_test_tt_main suite

--- a/rio/tests/progs/work_conserving/rr_ACD.sched
+++ b/rio/tests/progs/work_conserving/rr_ACD.sched
@@ -1,0 +1,5 @@
+classes A, C, D;
+
+policy = rr[A, C, D];
+
+return policy

--- a/rio/tests/progs/work_conserving/rr_A_strictBCD.sched
+++ b/rio/tests/progs/work_conserving/rr_A_strictBCD.sched
@@ -1,0 +1,9 @@
+classes A, B, C, D;
+
+// Used by the alignment-aware test pair: against [rr_A_strictBC_E] this
+// is the longer-arm side ([SP[B,C,D]] morphs to [SP[B,C]] and a fresh
+// sibling [E] appears at the RR level). After [Pol.normalize] this is
+// RR[FIFO A, SP[(B,1),(C,2),(D,3)]] (FIFO < SP by polymorphic compare).
+policy = rr[A, strict[(B, 1), (C, 2), (D, 3)]];
+
+return policy

--- a/rio/tests/progs/work_conserving/rr_A_strictBC_E.sched
+++ b/rio/tests/progs/work_conserving/rr_A_strictBC_E.sched
@@ -1,0 +1,9 @@
+classes A, B, C, E;
+
+// Used by the alignment-aware test pair: against [rr_A_strictBCD] this
+// adds [E] as a fresh RR sibling and the inner SP retires its [D] arm.
+// After [Pol.normalize] this is RR[FIFO A, FIFO E, SP[(B,1),(C,2)]] (FIFO
+// < SP, and FIFO A < FIFO E alphabetically).
+policy = rr[A, strict[(B, 1), (C, 2)], E];
+
+return policy

--- a/rio/tests/progs/work_conserving/sp_A_rrBCD.sched
+++ b/rio/tests/progs/work_conserving/sp_A_rrBCD.sched
@@ -1,0 +1,10 @@
+classes A, B, C, D;
+
+// Used by the SP-side alignment-aware test pair: against [sp_A_rrBC_E] this
+// is the longer-arm side ([rr[B,C,D]] morphs to [rr[B,C]] and a fresh
+// sibling [E] appears at the outer SP level). After [Pol.normalize] this is
+// SP[(FIFO A, 1.0); (RR[FIFO B; FIFO C; FIFO D], 2.0)] (SP sorts children
+// by rank ascending).
+policy = strict[(A, 1), (rr[B, C, D], 2)];
+
+return policy

--- a/rio/tests/progs/work_conserving/sp_A_rrBC_E.sched
+++ b/rio/tests/progs/work_conserving/sp_A_rrBC_E.sched
@@ -1,0 +1,9 @@
+classes A, B, C, E;
+
+// Used by the SP-side alignment-aware test pair: against [sp_A_rrBCD] this
+// adds [E] as a fresh outer SP sibling at rank 3 and the inner RR retires
+// its [D] arm. After [Pol.normalize] this is SP[(FIFO A, 1.0); (RR[FIFO B;
+// FIFO C], 2.0); (FIFO E, 3.0)] (SP sorts children by rank ascending).
+policy = strict[(A, 1), (rr[B, C], 2), (E, 3)];
+
+return policy

--- a/rio/tests/progs/work_conserving/strict_ACD.sched
+++ b/rio/tests/progs/work_conserving/strict_ACD.sched
@@ -1,0 +1,5 @@
+classes A, C, D;
+
+policy = strict[(A, 1), (C, 2), (D, 3)];
+
+return policy

--- a/rio/tests/progs/work_conserving/wfq_A_rrBCD.sched
+++ b/rio/tests/progs/work_conserving/wfq_A_rrBCD.sched
@@ -1,0 +1,10 @@
+classes A, B, C, D;
+
+// Used by the WFQ-side alignment-aware test pair: against [wfq_A_rrBC_E]
+// this is the longer-arm side ([rr[B,C,D]] morphs to [rr[B,C]] and a fresh
+// sibling [E] appears at the outer WFQ level). After [Pol.normalize] this
+// is WFQ[(FIFO A, 1.0); (RR[FIFO B; FIFO C; FIFO D], 2.0)] (WFQ sorts
+// children by arm content first; FIFO < RR by polymorphic compare).
+policy = wfq[(A, 1), (rr[B, C, D], 2)];
+
+return policy

--- a/rio/tests/progs/work_conserving/wfq_A_rrBC_E.sched
+++ b/rio/tests/progs/work_conserving/wfq_A_rrBC_E.sched
@@ -1,0 +1,12 @@
+classes A, B, C, E;
+
+// Used by the WFQ-side alignment-aware test pair: against [wfq_A_rrBCD]
+// this adds [E] at the outer WFQ level and the inner RR retires its [D]
+// arm. After [Pol.normalize] this is WFQ[(FIFO A, 1.0); (FIFO E, 3.0);
+// (RR[FIFO B; FIFO C], 2.0)] (WFQ sorts by arm content first: among the
+// FIFOs A < E alphabetically, and FIFO < RR). The reordering puts FIFO E
+// between A and the RR, so the label-set alignment emits a non-contiguous
+// Add at index 1 and a matched-pair edit on the RR at index 2.
+policy = wfq[(A, 1), (rr[B, C], 2), (E, 3)];
+
+return policy

--- a/rio/tests/progs/work_conserving/wfq_Z_rrAY_rrCW.sched
+++ b/rio/tests/progs/work_conserving/wfq_Z_rrAY_rrCW.sched
@@ -1,0 +1,13 @@
+classes A, C, W, Y, Z;
+
+// Same-length cross-slot bidir test fixture (worklist item 20). Against
+// [wfq_ABC] (which normalizes to WFQ[(A, 2); (B, 1); (C, 3)]) this exercises
+// the bidir fallback in [compare_metaed_children]'s same-length branch:
+// after [Pol.normalize] sorts by arm content, this becomes
+// WFQ[(Z, 4); (RR[A, Y], 7); (RR[C, W], 8)] (FIFO < RR; among the RRs,
+// [A,Y] < [C,W]). The two sides align as A->RR[A,Y] (i1=0, j2=1) and
+// C->RR[C,W] (i1=2, j2=2), with B retiring and Z added; the first match's
+// [i1 <> j2] triggers the bidir emit rather than three slot-level Replaces.
+policy = wfq[(Z, 4), (rr[A, Y], 7), (rr[C, W], 8)];
+
+return policy


### PR DESCRIPTION
The planner now examines the _flows_ that a tree arbitrates, and so it can compare two trees to see if a flow has been added or removed. The upshot is that we can now sniff out:

`RR(A,SP(B,C,D))` changing to `RR(A,SP(B,C),E)`

That is, an arm added in one place and an arm retired elsewhere.