### PR TITLE
Check for SubPol once, then don't check for it in the recursion

### DIFF
--- a/paper/sketch.md
+++ b/paper/sketch.md
@@ -1158,8 +1158,7 @@ The planner discharges this by construction (each case below emits a `δ` or idi
 
 §5.1 sets up _confinement_ as a metric for excellence, presents the always-available worst-case `Replace` fallback, and frames the planner's strategy as descending the tree to find a tight production (Add, Remove, ChangeMeta) that captures the difference locally.
 §5.2 catalogs the cases the planner recognizes and emits a tight sequence for.
-§5.3 explains one non-obvious wrinkle: a recursive case whose inner result cannot bubble cleanly to the outer slot, forcing a demotion.
-§5.4 lists three deliberate non-features and candidate future work.
+§5.3 lists deliberate non-features and candidate future work.
 
 ### 5.1 The Always-Available Fallback, and Confinement to do Better
 
@@ -1223,8 +1222,10 @@ We claim only that whatever sequence it emits is safe (§3.4) and no worse than 
 ### 5.2 The case analysis
 
 The planner steps through the following cases in order, emitting at the first match.
-Each call examines the current pair `(p1, p2)`: cases 1-3 test the two trees as wholes; cases 4-8 fire when the roots agree and the local difference has a recognized shape; case 9 catches everything else.
-Cases 4 and 5 are the descent mechanism: when the difference sits one level down, they re-enter this case analysis on the differing slot, and whatever case fires at the deeper level has its emission re-targeted via index prepending on the way back up.
+The operator's top-level call examines `(p1, p2)` as whole trees: cases 1-3 fire when one tree equals the other or embeds in it; cases 4-8 fire when the roots agree and the local difference has a recognized shape; case 9 catches everything else.
+Cases 4, 5, and 8 are the descent mechanism: when the difference sits one level down, they re-enter the case analysis on the differing slot, and whatever case fires at the deeper level has its emission re-targeted via index prepending on the way back up.
+Cases 2 and 3 are skipped at every deeper entry: `Graft` and `PruneDownTo` describe whole-tree edits whose paths name positions in the running policy as a whole (§3.4.8, §3.4.7), and so cannot be retargeted into a parent slot by index prepending.
+A sub-policy embedding noticed at depth therefore falls through to the constructor cases below and emits a slot-level `Replace` directly, identical to what case 9 would do.
 
 1. **`p1 = p2`.**
    Emit `[]`.
@@ -1244,8 +1245,7 @@ Cases 4 and 5 are the descent mechanism: when the difference sits one level down
    When the children's class-label sets reveal a cleaner cross-slot pairing than slot position does (a slot's arm in `p1` shares labels with a different slot's arm in `p2`), the planner takes case 8's label-overlap alignment instead.
    Otherwise it walks each slot independently and emits one slot-level edit per diverging position; slot-level edits target distinct indices and so concatenate freely in ascending order.
    At a slot whose arm agrees, nothing is emitted.
-   At a slot whose arm differs, recurse on the inner pair and dispatch on the inner shape: a non-bubbleable inner (single `Graft`, or a sequence ending in `ChangeRoot`) demotes to a slot-level `Replace` at the outer position; any other inner sequence bubbles via index-prepending.
-   §5.3 covers the demotion wrinkle.
+   At a slot whose arm differs, recurse on the inner pair (skipping cases 2 and 3) and bubble the inner emission via index-prepending.
 
 5. **`SP` or `WFQ` at the current level, child lists of equal length.**
    When `p1` and `p2` carry the same multiset of arms (the operator has simply re-weighted or re-ranked existing arms, which §3.2's normalization re-sorts into possibly-different slots), the planner emits one `ChangeMeta` per slot whose meta has moved and is done at this level.
@@ -1253,7 +1253,7 @@ Cases 4 and 5 are the descent mechanism: when the difference sits one level down
    Otherwise it walks each slot independently and emits one slot-level edit per diverging position; slot-level edits target distinct indices and so concatenate freely in ascending order.
    At a slot whose arm and metadata both agree, nothing is emitted.
    At a slot whose metadata differs but whose arm does not, emit `ChangeMeta(path, meta)` for that slot.
-   At a slot whose arm differs (with or without a metadata change at the same slot), recurse on the inner pair and dispatch on the inner shape: a `Replace`-root inner takes any metadata change as a trailing `ChangeMeta` of its bubbled emission; a non-bubbleable inner (single `Graft`, or a sequence ending in `ChangeRoot`) demotes to a slot-level `Replace` at the outer position, carrying the metadata when present; any clean smaller inner edit bubbles via index-prepending and, when the metadata also changed, picks up a separate `ChangeMeta` step at the slot.
+   At a slot whose arm differs (with or without a metadata change at the same slot), recurse on the inner pair (skipping cases 2 and 3) and dispatch on the inner shape: a `Replace`-root inner folds any metadata change into its trailing `ChangeMeta`; any other inner edit bubbles via index-prepending and, when the metadata also changed, picks up a separate `ChangeMeta` step at the slot.
 
 6. **Same constructor at the current level, every child of `p1` is also a child of `p2` but `p2` has more children.**
    Emit one `Add` per surplus arm, in ascending index order.
@@ -1271,10 +1271,10 @@ Cases 4 and 5 are the descent mechanism: when the difference sits one level down
    Cases 4 and 5 pivot here when class-labels reveal a cross-slot correspondence, and cases 6 and 7 fall through here when the lengths differ but neither side's arms are a subset of the other's.
    Arms in `p1` and `p2` whose class-label sets overlap pair up by a greedy left-to-right walk.
    Arms in `p1` with no overlapping partner in `p2` retire; arms in `p2` with no overlapping partner in `p1` are added; the two can coexist at the same parent.
-   `Retire`s fire first in descending `p1`-index order, `Add`s next in ascending `p2`-index order; matched-pair edits then recurse on the inner pair and bubble to the slot's position in `p2`'s post-mutation frame, subject to the §5.3 demotion rule.
-   At an `SP` or `WFQ` parent each `Add` carries its meta, and a matched pair whose metas also differ folds a `ChangeMeta` into the recursive edit (either as a trailing step on a clean bubble or as the meta argument to a demoted `Replace`).
+   `Retire`s fire first in descending `p1`-index order, `Add`s next in ascending `p2`-index order; matched-pair edits then recurse on the inner pair (skipping cases 2 and 3) and bubble to the slot's position in `p2`'s post-mutation frame.
+   At an `SP` or `WFQ` parent each `Add` carries its meta, and a matched pair whose metas also differ folds a `ChangeMeta` into the recursive edit (as a trailing step on the bubbled inner emission).
    The pairing relies on §3.2's leaf-partition validity: a class label identifies a unique flow across the whole policy, so a repeated label between an arm in `p1` and an arm in `p2` is evidence that the same host arm has morphed, and an arm whose labels appear nowhere on the opposing side is necessarily a fresh sibling or a vanishing one.
-   The greedy walk is not complete: when more than one alignment satisfies the label-overlap constraint, the first one found is taken without a notion of cost (§5.4).
+   The greedy walk is not complete: when more than one alignment satisfies the label-overlap constraint, the first one found is taken without a notion of cost (§5.3).
    When no shared label admits even a single match, the case fails and the planner falls through to case 9; this keeps wholesale divergence (no anchoring overlap) from emptying the parent mid-sequence.
 
 9. **Anything else.**
@@ -1282,30 +1282,12 @@ Cases 4 and 5 are the descent mechanism: when the difference sits one level down
    "Anything else" covers same-level shapes the planner does not recognize: constructor mismatch (e.g., `SP` vs. `RR`), and child lists of unequal length where neither's children are a subset of the other's and case 8's label-set walk fails to find an alignment.
 
    The recursion does significant work here.
-   Cases 1-8 are tried at every level the recursion visits, and cases 4, 5, and 8 descend into agreeing or label-overlapping slots of their parents.
+   Case 1 and cases 4-9 are tried at every level the recursion visits, and cases 4, 5, and 8 descend into agreeing or label-overlapping slots of their parents.
    By the time case 9 fires at level `k`, every shallower level has matched a tight case; the resulting `Replace` therefore lands at the _deepest slot the planner could isolate the difference to_, leaving every ancestor's other subtrees running undisturbed.
    The slot-level `Replace` is the §5.1 idiom with a non-empty path: it wraps only the slot's subtree, quiesces only that subtree, and rewires only the parent edge into it.
    The worst case is a root-level `Replace([], p2)` (§5.1), reached only when case 9 fires at the root with no recursive descent.
 
-### 5.3 Demotion: when an inner result cannot bubble
-
-Cases 4 and 5 above each recurse into a slot's contents and prepend the slot's index to every step of the inner result.
-This is correct when the inner sequence describes an edit on the slot's _occupants_ in a way that survives retargeting.
-It fails for two inner shapes.
-
-Suppose the running policy is `RoundRobin(A, B)` and the operator requests `RoundRobin(A, C(B))` (some 1-ary discipline `C` wrapping `B`).
-Case 4 fires at the root: lengths agree (both are 2-ary), one child differs (index 1).
-Recursing on `B` vs. `C(B)` falls into case 2: `B` embeds in `C(B)`, so the inner recursion returns `[(true, Graft(C(□)))]`.
-Bubbling this inner step by prepending index 1 would yield `[(true, Graft(C(□)))]` _at the outer slot_, which is not the edit the operator requested: `Graft`'s denotation acts on the whole running tree (per §3.4.8), not on the bubbled-up slot, so the prepended path would mis-describe the edit.
-
-The planner detects this shape (the inner result is a single `Graft` step, or it ends in `ChangeRoot` as `PruneDownTo`'s tail does) and _demotes_ to a slot-level `Replace` at the outer position; when the demoting recognizer is case 5 and the slot's metadata is also changing, the demoted `Replace` carries the new metadata as its trailing `ChangeMeta` step.
-Demotion is a deliberate downgrade in confinement (we land at case 9 for that slot rather than the tight inner `δ` we hoped for), but it is the price of recognizing that `Graft` and `PruneDownTo` describe _whole-tree edits only_.
-
-A future planner could do better here.
-A multi-`Add`-aware planner would recognize the running example as a single `Add` at the new `C` node (after standing it up via an outer rewrite), and avoid the demotion.
-We leave that to future work; see §5.4.
-
-### 5.4 What the planner does not do today
+### 5.3 What the planner does not do today
 
 Two deliberate non-features, each a candidate for future work.
 

--- a/rio/planner/planner.ml
+++ b/rio/planner/planner.ml
@@ -217,20 +217,6 @@ let prune_down_to ~prev ~path () =
   in
   walk prev path [] @ [ (True, Delta.ChangeRoot (List.map (fun _ -> 0) path)) ]
 
-(* Sequence-shape introspection for the comparators' demotion paths:
-   [compare_children] and [compare_metaed_children] each call into [analyze]
-   recursively on children, then need to recognize "this inner sequence
-   describes a relationship between children that doesn't bubble up to the
-   outer slot" and demote to a slot-level give-up. The two predicates below
-   are the only such recognizers. *)
-
-(* Recognize a [PruneDownTo] sequence's tail: any sequence whose last step is
-   [ChangeRoot]. Used by [compare_children]'s demotion match. *)
-let ends_in_change_root seq =
-  match List.rev seq with
-  | (_, Delta.ChangeRoot _) :: _ -> true
-  | _ -> false
-
 (* Recognize the inner [Replace] shape (pre-bubble-up). Used by the metaed
    comparator to gate "slot-replace-with-meta" rewrites. *)
 let is_replace_root = function
@@ -317,20 +303,11 @@ let rec is_sub_policy p1 p2 =
 
 let rec compare_children ~next:p2 ps1 ps2 =
   let give_up = replace ~next:p2 () in
-  (* Emit a slot-level edit at index [i] carrying [arm1] to [arm2]. A
-     non-bubbleable inner shape (nested [Graft] or [PruneDownTo]) demotes
-     to a slot-level [Replace] at this level; any other inner sequence
-     bubbles via [prepend_seq]. *)
-  let slot_arm_edit i arm1 arm2 =
-    let inner = analyze arm1 arm2 in
-    let non_bubbleable =
-      match inner with
-      | [ (True, Delta.Graft _) ] -> true
-      | _ -> ends_in_change_root inner
-    in
-    if non_bubbleable then prepend_seq i (replace ~next:arm2 ())
-    else prepend_seq i inner
-  in
+  (* Emit a slot-level edit at index [i] carrying [arm1] to [arm2]. The
+     inner sequence always bubbles via [prepend_seq]: [analyze_inner]
+     never returns a [Graft] or [PruneDownTo] (those are top-level only;
+     see [analyze]), so no demotion check is needed here. *)
+  let slot_arm_edit i arm1 arm2 = prepend_seq i (analyze_inner arm1 arm2) in
   match List.compare_lengths ps1 ps2 with
   | 0 ->
       (* Same-length fallback to bidirectional label-set alignment: when
@@ -415,32 +392,26 @@ and compare_metaed_children ~next:p2 pms1 pms2 =
   let ms1 = List.map snd pms1 in
   let ms2 = List.map snd pms2 in
   (* Emit a slot-level edit at index [i], carrying [arm1] to [arm2] and
-     optionally rebinding the slot's meta. Three sub-cases by inner shape:
-     a non-bubbleable inner (nested [Graft] or [PruneDownTo]) demotes to a
-     slot-level [Replace] (with meta); a [Replace]-root inner takes the
-     meta in its trailing [ChangeMeta]; any other clean inner edit bubbles
-     via [prepend_seq] with a separate [ChangeMeta] for the meta change. *)
+     optionally rebinding the slot's meta. Two sub-cases by inner shape: a
+     [Replace]-root inner takes the meta in its trailing [ChangeMeta]; any
+     other clean inner edit bubbles via [prepend_seq] with a separate
+     [ChangeMeta] for the meta change. [analyze_inner] never returns a
+     [Graft] or [PruneDownTo] (those are top-level only; see [analyze]),
+     so no demotion check is needed. *)
   let slot_arm_edit i arm1 arm2 ?meta () =
-    let inner = analyze arm1 arm2 in
-    let non_bubbleable =
-      match inner with
-      | [ (True, Delta.Graft _) ] -> true
-      | _ -> ends_in_change_root inner
-    in
-    if non_bubbleable then prepend_seq i (replace ~next:arm2 ?meta ())
-    else
-      match (meta, is_replace_root inner) with
-      | Some m, true ->
-          let survivor =
-            match inner with
-            | (True, Delta.Designate { survivor; _ }) :: _ -> survivor
-            | _ -> assert false
-          in
-          prepend_seq i (replace ~next:survivor ~meta:m ())
-      | Some m, false ->
-          prepend_seq i inner
-          @ [ (True, Delta.ChangeMeta { path = [ i ]; new_meta = m }) ]
-      | None, _ -> prepend_seq i inner
+    let inner = analyze_inner arm1 arm2 in
+    match (meta, is_replace_root inner) with
+    | Some m, true ->
+        let survivor =
+          match inner with
+          | (True, Delta.Designate { survivor; _ }) :: _ -> survivor
+          | _ -> assert false
+        in
+        prepend_seq i (replace ~next:survivor ~meta:m ())
+    | Some m, false ->
+        prepend_seq i inner
+        @ [ (True, Delta.ChangeMeta { path = [ i ]; new_meta = m }) ]
+    | None, _ -> prepend_seq i inner
   in
   match List.compare_lengths ps1 ps2 with
   | 0 ->
@@ -586,24 +557,35 @@ and compare_metaed_children ~next:p2 pms1 pms2 =
       end
   | _ -> failwith "Can't get here"
 
-and analyze p1 p2 =
+(* Inner recursion entry: same as [analyze] but skips the [is_sub_policy]
+   checks. [Graft] and [PruneDownTo] are whole-tree edits whose paths name
+   positions in the *root* control; they cannot be retargeted into a parent
+   slot by [prepend_seq] (paper sketch.md sec5.2). So inner recursions
+   never emit them: a sub-policy embedding at a deeper level falls through
+   to the constructor cases and emits a slot-level [Replace], which is the
+   same observable behavior as the previous "demote to give-up" rule. *)
+and analyze_inner p1 p2 =
+  if p1 = p2 then []
+  else
+    match (p1, p2) with
+    | SP (pms1, _), SP (pms2, _) | WFQ pms1, WFQ pms2 ->
+        compare_metaed_children ~next:p2 pms1 pms2
+    | RR ps1, RR ps2 -> compare_children ~next:p2 ps1 ps2
+    | _ ->
+        (* FIFO->FIFO with different class, or any constructor mismatch
+           (FIFO<->SP, SP<->RR, etc.): whole-slot give-up at this level.
+           The leaf-level paths are empty; [prepend_seq] pins them when
+           this bubbles up. *)
+        replace ~next:p2 ()
+
+let analyze p1 p2 =
   if p1 = p2 then []
   else
     match (is_sub_policy p1 p2, is_sub_policy p2 p1) with
     | Some _, Some _ -> [] (* unreachable: would mean p1 = p2 *)
     | Some path, None -> [ (True, Delta.Graft path) ]
     | None, Some path -> prune_down_to ~prev:p1 ~path ()
-    | _ -> (
-        match (p1, p2) with
-        | SP (pms1, _), SP (pms2, _) | WFQ pms1, WFQ pms2 ->
-            compare_metaed_children ~next:p2 pms1 pms2
-        | RR ps1, RR ps2 -> compare_children ~next:p2 ps1 ps2
-        | _ ->
-            (* FIFO->FIFO with different class, or any constructor mismatch
-               (FIFO<->SP, SP<->RR, etc.): whole-slot give-up at this level.
-               The leaf-level paths are empty; [prepend_seq] pins them when
-               this bubbles up. *)
-            replace ~next:p2 ())
+    | None, None -> analyze_inner p1 p2
 
 (* -------- pretty-printing (test output only) ---------------- *)
 

--- a/rio/tests/planner/test_planner.ml
+++ b/rio/tests/planner/test_planner.ml
@@ -245,10 +245,11 @@ let one_arm_replaced_wfq =
 
 (* Same-length RR parent where more than one slot diverges. Each diverging
    slot emits its own slot-level edit; the emissions target distinct indices
-   and concatenate in ascending order with no interference. Same demotion
-   rules as the metaed variant below: a non-bubbleable inner shape
-   ([Graft]/[PruneDownTo]) demotes to a slot-level [Replace]; any other
-   inner sequence bubbles via [prepend_seq]. *)
+   and concatenate in ascending order with no interference. The inner
+   recursion always bubbles via [prepend_seq]: [Graft] and [PruneDownTo]
+   are top-level-only emissions, so an inner pair whose constructors
+   disagree (e.g. [FIFO B] vs [RR [B; C]]) falls through to a slot-level
+   [Replace] directly. *)
 let multi_arms_replaced =
   [
     make_planner_test "RR with every slot differing" "rr_ABC" "rr_DEF"
@@ -256,12 +257,11 @@ let multi_arms_replaced =
       @ replace_seq [ 1 ] (Pol.FIFO "E")
       @ replace_seq [ 2 ] (Pol.FIFO "F"));
     (* rr_rrBC_D normalizes to RR[FIFO D, RR[B, C]]; rr_AB is RR[A, B].
-       Slot 0 is a clean cross-class Replace. Slot 1's inner analyze is a
-       [PruneDownTo] (FIFO B sits inside RR[B, C]); the resulting sequence
-       ends in [ChangeRoot] and so demotes to a slot-level [Replace],
-       confirming that the per-slot walk applies the demotion rule
-       independently at each diverging slot. *)
-    make_planner_test "RR multi-slot with one slot demoting" "rr_rrBC_D" "rr_AB"
+       Slot 0 is a clean cross-class Replace. Slot 1's inner analyze runs
+       on [RR[B, C]] vs [FIFO B]: the constructors disagree, so it emits a
+       slot-level [Replace] directly (no [PruneDownTo] at depth). *)
+    make_planner_test "RR multi-slot with constructor-mismatch inner"
+      "rr_rrBC_D" "rr_AB"
       (replace_seq [ 0 ] (Pol.FIFO "A") @ replace_seq [ 1 ] (Pol.FIFO "B"));
   ]
 
@@ -270,8 +270,8 @@ let multi_arms_replaced =
    slot emits its own slot-level edit independently; the per-slot emissions
    target distinct indices and concatenate in ascending order with no
    interference. Sub-cases by inner-recursion shape: a [Replace]-root inner
-   takes any meta change as a trailing [ChangeMeta]; a non-bubbleable inner
-   ([Graft]/[PruneDownTo]) demotes to a slot-level [Replace] (with meta if
+   takes any meta change as a trailing [ChangeMeta]; a constructor-mismatch
+   inner emits a slot-level [Replace] directly (with meta if
    applicable); any clean smaller inner edit bubbles via [prepend_seq] with
    a separate [ChangeMeta] for the meta change. *)
 let multi_arms_replaced_metaed =
@@ -483,13 +483,17 @@ let same_length_bidir =
       @ replace_seq ~meta:8.0 [ 2 ] (Pol.RR [ Pol.FIFO "C"; Pol.FIFO "W" ]));
   ]
 
-let nested_giveup_demotion =
+(* Pairs that would have looked like sub-policy embeddings at depth (FIFO B
+   inside RR[B,C], or vice versa) but whose containing slots are non-equal:
+   the inner analyze sees only a constructor mismatch (FIFO vs RR) and
+   emits a slot-level [Replace] directly. [Graft] and [PruneDownTo] are
+   reserved for whole-tree (top-level) embeddings; recursive calls skip
+   the sub-policy test. *)
+let nested_constructor_mismatch =
   [
-    make_planner_test "nested Graft demotes to give-up" "strict_AB"
-      "strict_A_rrBC"
+    make_planner_test "inner FIFO -> RR around it" "strict_AB" "strict_A_rrBC"
       (replace_seq [ 1 ] (Pol.RR [ Pol.FIFO "B"; Pol.FIFO "C" ]));
-    make_planner_test "nested ChangeRoot demotes to give-up" "strict_A_rrBC"
-      "strict_AB"
+    make_planner_test "inner RR -> FIFO inside it" "strict_A_rrBC" "strict_AB"
       (replace_seq [ 1 ] (Pol.FIFO "B"));
   ]
 
@@ -538,6 +542,6 @@ let suite =
        @ one_arm_replaced_wfq @ multi_arms_replaced @ multi_arms_replaced_metaed
        @ add_with_shared_meta_change @ aligned_multi @ mixed_add_retire
        @ same_length_bidir @ verydiff_combos @ graft @ change_root
-       @ nested_giveup_demotion
+       @ nested_constructor_mismatch
 
 let () = run_test_tt_main suite


### PR DESCRIPTION
Closes #137 

Hoisted the `is_sub_policy p2 p1` check to a one-shot top-level call in `analyze`; inner recursions now go through `analyze_inner`, which skips case 2 (`PruneDownTo`) and falls through to the constructor cases on any sub-policy embedding noticed at depth.

This is a reasonable move since `PruneDownTo` can only ever be run on the whole `p1` anyway, so throwing the `is_sub_pol` check into the inner recursion was useless. Even if detected, it was being "demoted" to a Replace.